### PR TITLE
Expose to local scope object rather than global window.

### DIFF
--- a/dice-roller.js
+++ b/dice-roller.js
@@ -126,7 +126,7 @@
    *
    * @constructor
    */
-  root.DiceRoller = function(){
+  var DiceRoller = function(){
     var lib = this;
 
     /*
@@ -363,7 +363,7 @@
    * @param {string} notation  The dice notation
    * @constructor
    */
-  root.DiceRoll   = function(notation){
+  var DiceRoll   = function(notation){
     var lib = this;
 
     /**
@@ -652,4 +652,7 @@
     // initialise the object
     init(notation);
   };
+
+  root.DiceRoller = DiceRoller;
+  root.DiceRoll = DiceRoll;
 }(window));

--- a/dice-roller.js
+++ b/dice-roller.js
@@ -7,7 +7,7 @@
  * @link https://github.com/GreenImp/rpg-dice-roller
  */
 
-;(function(){
+;(function(root){
   "use strict";
 
   /**
@@ -126,7 +126,7 @@
    *
    * @constructor
    */
-  window.DiceRoller = function(){
+  root.DiceRoller = function(){
     var lib = this;
 
     /*
@@ -156,7 +156,7 @@
      * Returns a list of results
      *
      * @param {string} notation
-     * @returns {Window.DiceRoll}
+     * @returns {DiceRoll}
      */
     this.roll     = function(notation){
       var diceRoll;
@@ -313,7 +313,7 @@
           die.comparePoint  = {
             operator: '=',
             value:    die.fudge ? 1 : ((die.sides == '%') ? 100 : die.sides)
-          }
+          };
         }
 
         // check if we have additions
@@ -363,7 +363,7 @@
    * @param {string} notation  The dice notation
    * @constructor
    */
-  window.DiceRoll   = function(notation){
+  root.DiceRoll   = function(notation){
     var lib = this;
 
     /**


### PR DESCRIPTION
I plan to use this great library to implement some dice rolling utilities into a [TiddlyWiki](tiddlywiki.com) I use to manage my D&D campaign. However, the TiddlyWiki uses a CommonJS pattern of exposing the library functions on an exports variable rather than the global window.

These are changes that keep the functionality of the library identical but rather than assuming the global window throughout the code base, you use the global passed into the module function.

These changes now allow me to change only the `window` on the final line to `exports` in TiddlyWiki to have the library expose it when invoked with `require`