### PR TITLE
Implement UMD commonjsStrict pattern

### DIFF
--- a/dice-roller.js
+++ b/dice-roller.js
@@ -7,7 +7,18 @@
  * @link https://github.com/GreenImp/rpg-dice-roller
  */
 
-;(function(){
+;(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define([], factory);
+  } else if (typeof exports === 'object' && typeof exports.nodeName !== 'string') {
+    // CommonJS
+    factory(exports);
+  } else {
+    // Browser globals
+    factory(root);
+  }
+}(this, function(exports){
   "use strict";
 
   /**
@@ -126,7 +137,7 @@
    *
    * @constructor
    */
-  window.DiceRoller = function(){
+  var DiceRoller = function(){
     var lib = this;
 
     /*
@@ -156,7 +167,7 @@
      * Returns a list of results
      *
      * @param {string} notation
-     * @returns {Window.DiceRoll}
+     * @returns {DiceRoll}
      */
     this.roll     = function(notation){
       var diceRoll;
@@ -313,7 +324,7 @@
           die.comparePoint  = {
             operator: '=',
             value:    die.fudge ? 1 : ((die.sides == '%') ? 100 : die.sides)
-          }
+          };
         }
 
         // check if we have additions
@@ -363,7 +374,7 @@
    * @param {string} notation  The dice notation
    * @constructor
    */
-  window.DiceRoll   = function(notation){
+  var DiceRoll      = function(notation){
     var lib = this;
 
     /**
@@ -652,4 +663,7 @@
     // initialise the object
     init(notation);
   };
-}(window));
+
+  exports.DiceRoller = DiceRoller;
+  exports.DiceRoll = DiceRoll;
+}));


### PR DESCRIPTION
UMD CommonJS Strict:
  https://github.com/umdjs/umd/blob/master/templates/commonjsStrict.js

This allows the library to define it's module using AMD, CommonJS or a browser
global, usually window.

This changes the pattern slightly to provide the DiceRoller and DiceRoll
directly on the browser global as it was doing before. Therefore there are no
changes to this library when used in a browser however, it can now be used with
AMD or CommonJS as well.

Fixes #9 