### PR TITLE
Revert "Update dependencies"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
 language: node_js
 node_js:
   - "node"
-sudo: required
-addons:
-  chrome: stable

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "d&d"
   ],
   "devDependencies": {
-    "grunt": "^1.0.3",
+    "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
-    "grunt-contrib-jasmine": "^2.0.1",
+    "grunt-contrib-jasmine": "^1.0.3",
     "grunt-contrib-jshint": "^1.1.0",
-    "jshint": "^2.9.5"
+    "jshint": "^2.9.4"
   },
   "scripts": {
     "test": "grunt ci"


### PR DESCRIPTION
Reverts GreenImp/rpg-dice-roller#44

This included features from the ES6 port branch which were not meant to be included