### PR TITLE
Resolved bug with large addition numbers

### DIFF
--- a/dice-roller.js
+++ b/dice-roller.js
@@ -1078,7 +1078,7 @@
          * @type {string}
          */
         get addition() {
-          return '(' + this.arithmeticOperator + ')([1-9]+0?(?![0-9]*d)|H|L)';
+          return '(' + this.arithmeticOperator + ')([0-9]+(?![0-9]*d)|H|L)';
         },
         /**
          * Matches a standard dice notation. i.e;

--- a/tests/dice-roll.test.js
+++ b/tests/dice-roll.test.js
@@ -631,6 +631,28 @@
       });
     });
 
+    it('should return between 103 and 108 for `1d6+102', () => {
+      const notation = '1d6+102',
+            roll = diceRoller.roll(notation),
+            total = roll.total;
+
+      expect(roll).toEqual(jasmine.any(DiceRoll));
+
+      // check value is within allowed range
+      expect(total).toBeWithinRange({min: 103, max: 108});
+
+      // check the rolls list is correct
+      expect(roll).toHaveRolls({rolls: [1]});
+      expect(roll.rolls).toArraySumEqualTo(total-102);
+
+      // check the output string
+      expect(roll).toMatchParsedNotation({
+        notation: notation,
+        rolls: `[${total-102}]+102`,
+        total: total,
+      });
+    });
+
     it('should return between -1 and 2 for `1d4-2`', () => {
       const notation = '1d4-2',
             roll = diceRoller.roll(notation),

--- a/tests/notation-patterns.test.js
+++ b/tests/notation-patterns.test.js
@@ -58,7 +58,7 @@
        * @type {string}
        */
       get addition() {
-        return '(' + this.arithmeticOperator + ')([1-9]+0?(?![0-9]*d)|H|L)';
+        return '(' + this.arithmeticOperator + ')([0-9]+(?![0-9]*d)|H|L)';
       },
       /**
        * Matches a standard dice notation. i.e;


### PR DESCRIPTION
This PR solves #61 by adjusting the regex used to parse additions. Due to this change it is now also possible to have leading 0s before addition numbers.

Rolls like ```1d1 + 1d1200``` now correctly resolve to 1201.