### PR TITLE
Allow `dl` and `dh` to be used together

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -195,7 +195,9 @@ dF.1 // roll the variant fudge dice
 
 Modifiers a special flags that can change the value of dice rolls, their appearance, order, and more.
 
-You can generally combine multiple modifiers of different types and they'll work together. This will both [Explode](#explode) any maximum rolls, and [Keep](#keep-kn--khn--kln) only keep the highest 2 rolls:
+You can generally combine multiple modifiers of different types, and they'll work together.
+
+For example, This will both [Explode](#explode) any maximum rolls, and [Keep](#keep-kn--khn--kln) only keep the highest 2 rolls:
 
 ```
 5d10!k2
@@ -203,8 +205,12 @@ You can generally combine multiple modifiers of different types and they'll work
 
 We have tried to cover all the commonly used modifiers. [Let us know](https://github.com/GreenImp/rpg-dice-roller/issues) if we've missed one that you use!
 
+> *Note:* Modifiers are always run in a specific order, regardless of the order you specifying them in. This is determined by the modifier's `order` property, lowest first.
+
 
 #### Exploding (`!` / `!{cp}`)
+
+**Order:** 1
 
 The exploding dice mechanic allows one or more dice to be re-rolled (Usually when it rolls the highest possible number on the die), with each successive roll being added to the total.
 
@@ -284,12 +290,14 @@ You can also use [Compare Points](#Compare Point) to change when a dice will pen
 
 ```
 2d6!p=5   // penetrate on any rolls equal to 5
-2d6!!p>4   // penetrate and compound on any rolls greater than 4
+2d6!!p>4  // penetrate and compound on any rolls greater than 4
 4d10!p<=3 // penetrate on any roll less than or equal to 3
 ```
 
 
 #### Drop (`d{n}` / `dh{n}` / `dl{n}`)
+
+**Order:** 4
 
 Sometimes you may want roll a certain number of dice, but "drop" or remove high or low rolls from the results. It is the opposite of the Keep modifier.
 
@@ -300,9 +308,9 @@ The "end" is optional and, if omitted, will default to _lowest_.
 For example:
 
 ```
-4d10dl2 // roll a d10 4 times and drop the lowest 2 rolls
-4d10d2  // equivalent to the above
-4d10dh1 // roll a d10 4 times and drop the highest roll
+4d10dl2    // roll a d10 4 times and drop the lowest 2 rolls
+4d10d2     // equivalent to the above
+4d10dh1    // roll a d10 4 times and drop the highest roll
 ```
 
 When outputting the roll, the dropped rolls are given the "d" flag:
@@ -311,8 +319,19 @@ When outputting the roll, the dropped rolls are given the "d" flag:
 6d8dh3: [3, 6d, 7d, 2, 5d, 4] = 9
 ```
 
+You can also use "drop lowest" and "drop highest" modifiers together:
+
+```
+// roll a d10 4 times and drop the highest and lowest rolls
+4d10dh1dl2: [5, 3d, 7, 8d] = 12
+```
+
+> See the note in the [Keep modifier section](#keep-kn--khn--kln) regarding using the two together
+
 
 #### Keep (`k{n}` / `kh{n}` / `kl{n}`)
+
+**Order:** 3
 
 The keep modifier allows you to roll a collection of dice but to disregard all except for the highest or lowest result. It is the opposite of the Drop modifier.
 
@@ -325,7 +344,7 @@ For example:
 ```
 4d10kh2 // roll a d10 4 times and keep the highest 2 rolls
 4d10k2  // equivalent to the above
-4d10dl1 // roll a d10 4 times and keep the lowest roll
+4d10kl1 // roll a d10 4 times and keep the lowest roll
 ```
 
 When outputting the roll, the kept rolls aren't modified, but the dropped rolls are given the "d" flag:
@@ -334,8 +353,30 @@ When outputting the roll, the kept rolls aren't modified, but the dropped rolls 
 6d8k3: [3d, 6, 7, 2d, 5, 4d] = 9
 ```
 
+> _Note:_ The keep and drop modifiers work really well together, but there's some caveats.
+> They both look at the entire dice pool. So if a roll has been dropped, it will be still be included in the list of possible rolls to drop.
+> 
+> This means that using keep and drop modifiers together can override each other.
+> 
+> For example, the following will drop all of the rolls:
+> 
+> ```
+> 3d10k1dh1: [7d, 1d, 2d] = 0
+> ```
+> 
+> The is because the `k1` will drop the second and third dice, and the `dh1` will drop the first dice.
+> 
+> And this (perhaps more expectecdly) will only keep the highest dice:
+> ```
+> 3d10k1d1: [6d, 1d, 9] = 9
+> ```
+> 
+> The `k1` will drop the first and second rolls, and the `d1` will also drop the first roll.
+
 
 #### Re-roll (`r` / `ro` / `r{cp}` / `ro{cp}`)
+
+**Order:** 2
 
 This will re-roll a die that rolls the lowest possible number on a die (Usually a 1). It will keep re-rolling until a number greater than the minimum is rolled, disregarding any of the previous rolls.
 
@@ -365,6 +406,8 @@ Read more about [Compare Points below](#Compare Point).
 
 
 #### Target Success / Dice pool (`{cp}`)
+
+**Order:** 5
 
 Some systems use dice pool, or success counts, whereby the total is equal to the quantity of dice rolled that meet a fixed condition, rather than the total value of the rolls.
 
@@ -411,6 +454,8 @@ The result total will be the number of success, instead of the value of the roll
 
 #### Target Failures / Dice Pool (`f{cp}`)
 
+**Order:** 5
+
 Sometimes, when counting success, you also need to consider failures. A failure modifier _must_ directly follow a Success modifier, and works in much the same way.
 
 For each failure counted, it will subtract 1 from the total number of success counted.
@@ -423,6 +468,8 @@ The Failure modifier is a [Compare Point](#compare-point), preceded with the let
 
 
 #### Sorting (`s` / `sa` / `sd`)
+
+**Order:** 8
 
 You can sort the dice rolls, so that they are displayed in numerical order by appending the `s` flag after the dice notation.
 
@@ -437,6 +484,8 @@ The default order is ascending, but you can specify the sort order using `sa` an
 
 
 #### Critical Success (`cs{cp}`)
+
+**Order:** 6
 
 _This is purely aesthetic and makes no functional difference to the rolls or their values._
 
@@ -458,6 +507,8 @@ The roll result output will look something like this:
 
 
 #### Critical Failure (`cf{cp}`)
+
+**Order:** 7
 
 _This is purely aesthetic and makes no functional difference to the rolls or their values._
 

--- a/src/modifiers/KeepModifier.js
+++ b/src/modifiers/KeepModifier.js
@@ -44,6 +44,15 @@ class KeepModifier extends Modifier {
   }
 
   /**
+   * Returns the name for the modifier
+   *
+   * @returns {string}
+   */
+  get name() {
+    return `${super.name}-${this.end}`;
+  }
+
+  /**
    * Returns the quantity of dice that should be kept
    *
    * @returns {number}

--- a/src/modifiers/Modifier.js
+++ b/src/modifiers/Modifier.js
@@ -20,7 +20,7 @@ class Modifier {
   /**
    * Returns the name for the modifier
    *
-   * @returns {*}
+   * @returns {string}
    */
   get name() {
     return this.constructor.name;

--- a/src/parser/grammars/grammar.pegjs
+++ b/src/parser/grammars/grammar.pegjs
@@ -16,7 +16,7 @@ DiceGroup
         ...exprs.map(v => v[3])
       ],
       modifiers: Object.assign({}, ...modifiers.map(item => {
-        return {[item.constructor.name]: item};
+        return {[item.name]: item};
       })),
     };
   }
@@ -26,7 +26,7 @@ DiceGroup
 
 Dice = die:(StandardDie / PercentileDie / FudgeDie) modifiers:Modifier* {
   die.modifiers = Object.assign({}, ...modifiers.map(item => {
-    return {[item.constructor.name]: item};
+    return {[item.name]: item};
   }));
 
   return die;

--- a/tests/modifiers/DropModifier.test.js
+++ b/tests/modifiers/DropModifier.test.js
@@ -13,7 +13,7 @@ describe('DropModifier', () => {
       expect(mod).toBeInstanceOf(Modifier);
       expect(mod).toEqual(expect.objectContaining({
         end: 'l',
-        name: 'DropModifier',
+        name: 'DropModifier-l',
         notation: 'd1',
         run: expect.any(Function),
         toJSON: expect.any(Function),
@@ -73,7 +73,7 @@ describe('DropModifier', () => {
     });
 
     test('can be changed', () => {
-      const mod = new DropModifier('d1', 'h');
+      const mod = new DropModifier('dh', 'h');
 
       expect(mod.end).toEqual('h');
 
@@ -158,15 +158,15 @@ describe('DropModifier', () => {
 
   describe('Output', () => {
     test('JSON output is correct', () => {
-      const mod = new DropModifier('dl4', 'l', 4);
+      const mod = new DropModifier('dh4', 'h', 4);
 
       // json encode, to get the encoded string, then decode so we can compare the object
       // this allows us to check that the output is correct, but ignoring the order of the
       // returned properties
       expect(JSON.parse(JSON.stringify(mod))).toEqual({
-        end: 'l',
-        name: 'DropModifier',
-        notation: 'dl4',
+        end: 'h',
+        name: 'DropModifier-h',
+        notation: 'dh4',
         qty: 4,
         type: 'modifier',
       });

--- a/tests/modifiers/KeepModifier.test.js
+++ b/tests/modifiers/KeepModifier.test.js
@@ -13,7 +13,7 @@ describe('KeepModifier', () => {
       expect(mod).toBeInstanceOf(Modifier);
       expect(mod).toEqual(expect.objectContaining({
         end: 'h',
-        name: 'KeepModifier',
+        name: 'KeepModifier-h',
         notation: 'kh',
         run: expect.any(Function),
         toJSON: expect.any(Function),
@@ -158,15 +158,15 @@ describe('KeepModifier', () => {
 
   describe('Output', () => {
     test('JSON output is correct', () => {
-      const mod = new KeepModifier('kh4', 'h', 4);
+      const mod = new KeepModifier('kl4', 'l', 4);
 
       // json encode, to get the encoded string, then decode so we can compare the object
       // this allows us to check that the output is correct, but ignoring the order of the
       // returned properties
       expect(JSON.parse(JSON.stringify(mod))).toEqual({
-        end: 'h',
-        name: 'KeepModifier',
-        notation: 'kh4',
+        end: 'l',
+        name: 'KeepModifier-l',
+        notation: 'kl4',
         qty: 4,
         type: 'modifier',
       });

--- a/tests/parser/Parser.test.js
+++ b/tests/parser/Parser.test.js
@@ -326,9 +326,9 @@ describe('Parser', () => {
           expect(parsed[0].sides).toEqual(23);
           expect(parsed[0].qty).toEqual(19);
 
-          expect(parsed[0].modifiers.has('DropModifier')).toBe(true);
+          expect(parsed[0].modifiers.has('DropModifier-l')).toBe(true);
 
-          const mod = parsed[0].modifiers.get('DropModifier');
+          const mod = parsed[0].modifiers.get('DropModifier-l');
           expect(mod).toBeInstanceOf(DropModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
             notation: 'd1',
@@ -348,9 +348,9 @@ describe('Parser', () => {
           expect(parsed[0].sides).toEqual(10);
           expect(parsed[0].qty).toEqual(4);
 
-          expect(parsed[0].modifiers.has('DropModifier')).toBe(true);
+          expect(parsed[0].modifiers.has('DropModifier-l')).toBe(true);
 
-          const mod = parsed[0].modifiers.get('DropModifier');
+          const mod = parsed[0].modifiers.get('DropModifier-l');
           expect(mod).toBeInstanceOf(DropModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
             notation: 'dl1',
@@ -370,9 +370,9 @@ describe('Parser', () => {
           expect(parsed[0].sides).toEqual('%');
           expect(parsed[0].qty).toEqual(7);
 
-          expect(parsed[0].modifiers.has('DropModifier')).toBe(true);
+          expect(parsed[0].modifiers.has('DropModifier-l')).toBe(true);
 
-          const mod = parsed[0].modifiers.get('DropModifier');
+          const mod = parsed[0].modifiers.get('DropModifier-l');
           expect(mod).toBeInstanceOf(DropModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
             notation: 'd3',
@@ -392,9 +392,9 @@ describe('Parser', () => {
           expect(parsed[0].sides).toEqual(6);
           expect(parsed[0].qty).toEqual(4);
 
-          expect(parsed[0].modifiers.has('DropModifier')).toBe(true);
+          expect(parsed[0].modifiers.has('DropModifier-h')).toBe(true);
 
-          const mod = parsed[0].modifiers.get('DropModifier');
+          const mod = parsed[0].modifiers.get('DropModifier-h');
           expect(mod).toBeInstanceOf(DropModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
             notation: 'dh2',
@@ -610,9 +610,9 @@ describe('Parser', () => {
           expect(parsed[0].sides).toEqual(40601);
           expect(parsed[0].qty).toEqual(1);
 
-          expect(parsed[0].modifiers.has('KeepModifier')).toBe(true);
+          expect(parsed[0].modifiers.has('KeepModifier-h')).toBe(true);
 
-          const mod = parsed[0].modifiers.get('KeepModifier');
+          const mod = parsed[0].modifiers.get('KeepModifier-h');
           expect(mod).toBeInstanceOf(KeepModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
             notation: 'k1',
@@ -632,9 +632,9 @@ describe('Parser', () => {
           expect(parsed[0].sides).toEqual(2);
           expect(parsed[0].qty).toEqual(23017);
 
-          expect(parsed[0].modifiers.has('KeepModifier')).toBe(true);
+          expect(parsed[0].modifiers.has('KeepModifier-h')).toBe(true);
 
-          const mod = parsed[0].modifiers.get('KeepModifier');
+          const mod = parsed[0].modifiers.get('KeepModifier-h');
           expect(mod).toBeInstanceOf(KeepModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
             notation: 'kh1',
@@ -654,9 +654,9 @@ describe('Parser', () => {
           expect(parsed[0].sides).toEqual('F.2');
           expect(parsed[0].qty).toEqual(5);
 
-          expect(parsed[0].modifiers.has('KeepModifier')).toBe(true);
+          expect(parsed[0].modifiers.has('KeepModifier-h')).toBe(true);
 
-          const mod = parsed[0].modifiers.get('KeepModifier');
+          const mod = parsed[0].modifiers.get('KeepModifier-h');
           expect(mod).toBeInstanceOf(KeepModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
             notation: 'k4',
@@ -676,9 +676,9 @@ describe('Parser', () => {
           expect(parsed[0].sides).toEqual('%');
           expect(parsed[0].qty).toEqual(10);
 
-          expect(parsed[0].modifiers.has('KeepModifier')).toBe(true);
+          expect(parsed[0].modifiers.has('KeepModifier-l')).toBe(true);
 
-          const mod = parsed[0].modifiers.get('KeepModifier');
+          const mod = parsed[0].modifiers.get('KeepModifier-l');
           expect(mod).toBeInstanceOf(KeepModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
             notation: 'kl3',
@@ -1096,9 +1096,9 @@ describe('Parser', () => {
           expect(parsed[0].qty).toEqual(10);
 
 
-          expect(parsed[0].modifiers.has('DropModifier')).toBe(true);
+          expect(parsed[0].modifiers.has('DropModifier-h')).toBe(true);
 
-          let mod = parsed[0].modifiers.get('DropModifier');
+          let mod = parsed[0].modifiers.get('DropModifier-h');
           expect(mod).toBeInstanceOf(DropModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
             notation: 'dh2',
@@ -1107,9 +1107,9 @@ describe('Parser', () => {
           }));
 
 
-          expect(parsed[0].modifiers.has('KeepModifier')).toBe(true);
+          expect(parsed[0].modifiers.has('KeepModifier-l')).toBe(true);
 
-          mod = parsed[0].modifiers.get('KeepModifier');
+          mod = parsed[0].modifiers.get('KeepModifier-l');
           expect(mod).toBeInstanceOf(KeepModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
             notation: 'kl3',


### PR DESCRIPTION
Also allows `kh` and `kl` together, for consistency, although there's not much use as all dice will always be dropped.

Update readme.md

Resolves #129 