### PR TITLE
Dice have average value property

### DIFF
--- a/src/dice/StandardDice.js
+++ b/src/dice/StandardDice.js
@@ -45,6 +45,15 @@ class StandardDice {
   }
 
   /**
+   * The average value that the die can roll (Excluding modifiers)
+   *
+   * @returns {number}
+   */
+  get average() {
+    return (this.min + this.max) / 2;
+  }
+
+  /**
    * The modifiers that affect this dice roll
    *
    * @returns {Map|null}
@@ -192,10 +201,11 @@ class StandardDice {
    */
   toJSON() {
     const {
-      max, min, modifiers, name, notation, qty, sides,
+      average, max, min, modifiers, name, notation, qty, sides,
     } = this;
 
     return {
+      average,
       max,
       min,
       modifiers,

--- a/tests/dice/FudgeDice.test.js
+++ b/tests/dice/FudgeDice.test.js
@@ -156,6 +156,30 @@ describe('FudgeDice', () => {
     });
   });
 
+  describe('Average', () => {
+    test('average is correct for single die', () => {
+      let die = new FudgeDice('dF');
+      expect(die.average).toBe(0);
+
+      die = new FudgeDice('dF.1', 1);
+      expect(die.average).toBe(0);
+    });
+
+    test('average is unaffected when rolling multiple', () => {
+      let die = new FudgeDice('2dF', 2, 2);
+      expect(die.average).toBe(0);
+
+      die = new FudgeDice('400dF', 2, 400);
+      expect(die.average).toBe(0);
+
+      die = new FudgeDice('56dF.1', 1, 56);
+      expect(die.average).toBe(0);
+
+      die = new FudgeDice('145dF.1', 1, 145);
+      expect(die.average).toBe(0);
+    });
+  });
+
   describe('Modifiers', () => {
     test('setting modifiers in constructor calls setter', () => {
       const spy = jest.spyOn(FudgeDice.prototype, 'modifiers', 'set');
@@ -260,6 +284,7 @@ describe('FudgeDice', () => {
       // this allows us to check that the output is correct, but ignoring the order of the
       // returned properties
       expect(JSON.parse(JSON.stringify(die))).toEqual({
+        average: 0,
         max: 1,
         min: -1,
         modifiers: null,

--- a/tests/dice/PercentileDice.test.js
+++ b/tests/dice/PercentileDice.test.js
@@ -94,6 +94,30 @@ describe('PercentileDice', () => {
     });
   });
 
+  describe('Average', () => {
+    test('average is correct for single die', () => {
+      const die = new PercentileDice('d%');
+      expect(die.average).toBe(50.5);
+    });
+
+    test('average is unaffected when rolling multiple', () => {
+      let die = new PercentileDice('2d%', 2);
+      expect(die.average).toBe(50.5);
+
+      die = new PercentileDice('400d%', 400);
+      expect(die.average).toBe(50.5);
+
+      die = new PercentileDice('56d%', 56);
+      expect(die.average).toBe(50.5);
+
+      die = new PercentileDice('12d%', 12);
+      expect(die.average).toBe(50.5);
+
+      die = new PercentileDice('145d%', 145);
+      expect(die.average).toBe(50.5);
+    });
+  });
+
   describe('Modifiers', () => {
     test('setting modifiers in constructor calls setter', () => {
       const spy = jest.spyOn(PercentileDice.prototype, 'modifiers', 'set');
@@ -198,6 +222,7 @@ describe('PercentileDice', () => {
       // this allows us to check that the output is correct, but ignoring the order of the
       // returned properties
       expect(JSON.parse(JSON.stringify(die))).toEqual({
+        average: 50.5,
         max: 100,
         min: 1,
         modifiers: null,

--- a/tests/dice/StandardDice.test.js
+++ b/tests/dice/StandardDice.test.js
@@ -92,7 +92,7 @@ describe('StandardDice', () => {
       let die = new StandardDice('4d6', 6, 1);
       expect(die.qty).toBe(1);
 
-      die = new StandardDice('4d6', 6, 324);
+      die = new StandardDice('324d6', 6, 324);
       expect(die.qty).toBe(324);
 
       expect(() => {
@@ -106,6 +106,42 @@ describe('StandardDice', () => {
       expect(() => {
         die = new StandardDice('4d6', 6, -1);
       }).toThrow(TypeError);
+    });
+  });
+
+  describe('Average', () => {
+    test('average is correct for single die', () => {
+      let die = new StandardDice('d3', 3, 1);
+      expect(die.average).toBe(2);
+
+      die = new StandardDice('d10', 10, 1);
+      expect(die.average).toBe(5.5);
+
+      die = new StandardDice('d1', 1, 1);
+      expect(die.average).toBe(1);
+
+      die = new StandardDice('d20', 20, 1);
+      expect(die.average).toBe(10.5);
+
+      die = new StandardDice('d45', 45, 1);
+      expect(die.average).toBe(23);
+    });
+
+    test('average is unaffected when rolling multiple', () => {
+      let die = new StandardDice('2d3', 3, 2);
+      expect(die.average).toBe(2);
+
+      die = new StandardDice('400d10', 10, 400);
+      expect(die.average).toBe(5.5);
+
+      die = new StandardDice('56d1', 1, 56);
+      expect(die.average).toBe(1);
+
+      die = new StandardDice('12d20', 20, 12);
+      expect(die.average).toBe(10.5);
+
+      die = new StandardDice('145d45', 45, 145);
+      expect(die.average).toBe(23);
     });
   });
 
@@ -213,6 +249,7 @@ describe('StandardDice', () => {
       // this allows us to check that the output is correct, but ignoring the order of the
       // returned properties
       expect(JSON.parse(JSON.stringify(die))).toEqual({
+        average: 3.5,
         max: 6,
         min: 1,
         modifiers: null,


### PR DESCRIPTION
This add an `average` property to dice objects that returns the average value that it could roll.

e.g.
```javascript
let die = new StandardDice('d3', 3, 1);
// die.average === 2

die = new StandardDice('d10', 10, 1);
// die.average === 5.5

die = new PercentileDice('d%');
// die.average === 50.5

die = new FudgeDice('dF');
// die.average === 0

die = new FudgeDice('dF.1', 1);
// die.average === 0
```