### PR TITLE
Add functionality to generate TypeScript definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,8 @@ bower_components
 /lib/**/*.js
 /src/parser/grammars/grammar.js
 
+## Compiled TypeScript
+/types
+
 ## Testing
 /coverage

--- a/.npmignore
+++ b/.npmignore
@@ -4,7 +4,10 @@
 # Except for these
 !/lib/*.js
 !/lib/**/*.js
+!/types/*.d.ts
+!/types/**/*.d.ts
 !CONTRIBUTING.md
 !licence.txt
 !package.json
 !readme.md
+!tsconfig.json

--- a/declaration.tsconfig.json
+++ b/declaration.tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"extends": "./tsconfig",
+	"exclude": [
+	  "tests/**/*.js",
+	  "tests/**/*.ts"
+	],
+	"compilerOptions": {
+	  "declaration": true,
+	  "noEmit": false,
+	  "emitDeclarationOnly": true,
+	  "outDir": "types"
+	}
+  }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8653,6 +8653,12 @@
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
     },
+    "typescript": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
+      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
+      "dev": true
+    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "build:esm": "rollup --c --environment FORMAT:esm",
     "build:grammars": "node --experimental-modules src/parser/grammars/generate.js",
     "build:declaration": "rm -rf types/ && tsc -p declaration.tsconfig.json",
-    "prebuild": "npm run build:grammars",
+    "prebuild": "npm run build:grammars && npm run build:declaration",
     "watch": "npm run prebuild && npm run build:esm -- --environment BUILD:dev -w",
     "lint": "eslint src/** tests/**",
     "lint:fix": "eslint --fix src/** tests/**",
@@ -67,7 +67,7 @@
     "test:watch": "npm run lint && jest /tests/ --watchAll --coverage",
     "test:coverage": "jest /tests/ --coverage",
     "test:coveralls": "jest /tests/ --coverage && coveralls < coverage/lcov.info",
-    "prepublishOnly": "npm run build:prod && npm run build:dev && npm run test && npm run build:declaration"
+    "prepublishOnly": "npm run build:prod && npm run build:dev && npm run test"
   },
   "type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "build:umd": "rollup --c --environment FORMAT:umd",
     "build:esm": "rollup --c --environment FORMAT:esm",
     "build:grammars": "node --experimental-modules src/parser/grammars/generate.js",
+    "build:declaration": "rm -rf types/ && tsc -p declaration.tsconfig.json",
     "prebuild": "npm run build:grammars",
     "watch": "npm run prebuild && npm run build:esm -- --environment BUILD:dev -w",
     "lint": "eslint src/** tests/**",
@@ -66,8 +67,7 @@
     "test:watch": "npm run lint && jest /tests/ --watchAll --coverage",
     "test:coverage": "jest /tests/ --coverage",
     "test:coveralls": "jest /tests/ --coverage && coveralls < coverage/lcov.info",
-    "prepublishOnly": "npm run build:prod && npm run build:dev && npm run test",
-    "declaration:build": "rm -rf types/ && tsc -p declaration.tsconfig.json"
+    "prepublishOnly": "npm run build:prod && npm run build:dev && npm run test && npm run build:declaration"
   },
   "type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "lib/esm/bundle.js",
   "module": "lib/esm/bundle.js",
   "browser": "lib/umd/bundle.js",
+  "types": "types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/GreenImp/rpg-dice-roller.git"
@@ -40,7 +41,8 @@
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-eslint": "^6.0.0",
     "rollup-plugin-node-resolve": "^4.2.4",
-    "rollup-plugin-terser": "^5.3.0"
+    "rollup-plugin-terser": "^5.3.0",
+    "typescript": "^3.9.6"
   },
   "dependencies": {
     "mathjs-expression-parser": "^1.0.2"
@@ -64,7 +66,8 @@
     "test:watch": "npm run lint && jest /tests/ --watchAll --coverage",
     "test:coverage": "jest /tests/ --coverage",
     "test:coveralls": "jest /tests/ --coverage && coveralls < coverage/lcov.info",
-    "prepublishOnly": "npm run build:prod && npm run build:dev && npm run test"
+    "prepublishOnly": "npm run build:prod && npm run build:dev && npm run test",
+    "declaration:build": "rm -rf types/ && tsc -p declaration.tsconfig.json"
   },
   "type": "module"
 }

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,10 @@ A JS based dice roller that can roll various types of dice and modifiers, along 
 npm install rpg-dice-roller
 ```
 
+## Update TypeScript Definitions
+```bash
+npm run declaration:build
+```
 
 ## Documentation
 

--- a/readme.md
+++ b/readme.md
@@ -18,11 +18,6 @@ A JS based dice roller that can roll various types of dice and modifiers, along 
 npm install rpg-dice-roller
 ```
 
-## Update TypeScript Definitions
-```bash
-npm run declaration:build
-```
-
 ## Documentation
 
 Check out the documentation at [https://greenimp.github.io/rpg-dice-roller/](https://greenimp.github.io/rpg-dice-roller/).

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"files": [
+	  "src/index.js"
+	],
+	"include": [
+	  "tests/**/*.js",
+	  "tests/**/*.ts"
+	],
+	"compilerOptions": {
+	  /* Basic Options */
+	  "target": "ES2016",
+	  "module": "commonjs",
+	  "allowJs": true,
+	  "resolveJsonModule": true,
+	  "noEmit": true,
+	  "maxNodeModuleJsDepth": 3,
+  
+	  /* Strict Type-Checking Options */
+	  "strict": true,
+	  "noImplicitAny": true,
+	  "strictNullChecks": true,
+  
+	  /* Additional Checks */
+	  "noUnusedLocals": true
+	}
+}


### PR DESCRIPTION
> This replaces #151 

Based upon local testing (`npm install file:../..`), these changes appear to add proper TypeScript definitions to the library.

This change consists of the following:

1. Add TypeScript as a devDependency.
2. Add a new script to leverage TypeScript's built-in functionality to generate .d.ts files.
    - Note that I did try to have it generate one file, but couldn't get it to work, and looking at other projects they either are built with TypeScript, or are simpler. My hope is that adding some TS support will lead to someone with more knowledge than I improving the generation process. Or the library being rewritten in TypeScript. ;)
    - Git is marked to ignore the generated files in the types directory, which are built as part of the `prepublishOnly` script.

Based upon local testing, this then allows you to add the rpg-dice-roller package and import functionality (`import { DiceRoll } from 'rpg-dice-roller';`).

This relates to, and would close, #92 .