### PR TITLE
Remove the IIFE in the generated grammar file

### DIFF
--- a/src/parser/Parser.js
+++ b/src/parser/Parser.js
@@ -1,4 +1,4 @@
-import parser from './grammars/grammar';
+import * as parser from './grammars/grammar';
 import RequiredArgumentError from '../exceptions/RequiredArgumentErrorError';
 
 /**

--- a/src/parser/grammars/generate.js
+++ b/src/parser/grammars/generate.js
@@ -1,24 +1,34 @@
-/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable import/no-extraneous-dependencies, no-console */
 import fs from 'fs';
 import pegjs from 'pegjs';
 
 const dir = './src/parser/grammars/';
-const filename = 'grammar.js';
+const sourceFilename = 'grammar.pegjs';
+const outputFilename = 'grammar.js';
 
-// load the grammar
-const grammar = fs.readFileSync(`${dir}grammar.pegjs`).toString();
+// load the grammar file
+const grammar = fs.readFileSync(`${dir}${sourceFilename}`).toString();
 
-// generate the parser
-const parser = pegjs.generate(grammar, { output: 'source' });
+// generate the parser (as CommonJS)
+const parser = pegjs.generate(grammar, { output: 'source', format: 'commonjs' });
 
+// convert parser to ES module
 const output = `import * as Dice from '../../Dice';
 import * as Modifiers from '../../Modifiers';
 import ComparePoint from '../../ComparePoint';
 import RollGroup from '../../RollGroup';
 import math from 'mathjs-expression-parser';
 
-const parser = ${parser};
+const module = {};
 
-export default parser`;
+${parser}
 
-fs.writeFileSync(`${dir}${filename}`, output);
+export {
+  peg$SyntaxError as SyntaxError,
+  peg$parse as parse,
+}`;
+
+// create the file
+fs.writeFileSync(`${dir}${outputFilename}`, output);
+
+console.log(`Grammar parser saved to: ${dir}${outputFilename}`);

--- a/tests/parser/Parser.test.js
+++ b/tests/parser/Parser.test.js
@@ -6,7 +6,7 @@ import DropModifier from '../../src/modifiers/DropModifier';
 import ExplodeModifier from '../../src/modifiers/ExplodeModifier';
 import ReRollModifier from '../../src/modifiers/ReRollModifier';
 import KeepModifier from '../../src/modifiers/KeepModifier';
-import parser from '../../src/parser/grammars/grammar';
+import * as parser from '../../src/parser/grammars/grammar';
 import SortingModifier from '../../src/modifiers/SortingModifier';
 import TargetModifier from '../../src/modifiers/TargetModifier';
 import RequiredArgumentError from '../../src/exceptions/RequiredArgumentErrorError';


### PR DESCRIPTION
This makes it easier for scripts and IDEs to determine the functionality.