### PR TITLE
Allow changing of random number generator function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7138,6 +7138,11 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
+    "random-js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/random-js/-/random-js-2.1.0.tgz",
+      "integrity": "sha512-CRUyWmnzmZBA7RZSVGq0xMqmgCyPPxbiKNLFA5ud7KenojVX2s7Gv+V7eB52beKTPGxWRnVZ7D/tCIgYJJ8vNQ=="
+    },
     "react-is": {
       "version": "16.12.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "typescript": "^3.9.6"
   },
   "dependencies": {
-    "mathjs-expression-parser": "^1.0.2"
+    "mathjs-expression-parser": "^1.0.2",
+    "random-js": "^2.1.0"
   },
   "engines": {
     "node": ">=11.0"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,6 +17,10 @@ export default {
     file: `lib/${format}/bundle${production ? '.min' : ''}.js`,
     format,
     name: 'rpgDiceRoller',
+    // map external dependencies to variables, for UMD builds
+    globals: !es6 ? {
+      'random-js': 'randomJs',
+    } : {},
   },
   plugins: [
     // lint the files
@@ -34,4 +38,6 @@ export default {
       file: path.join(__dirname, 'banner.txt'),
     }),
   ],
+  // indicate which modules should be treated as external
+  external: [],
 };

--- a/src/dice/FudgeDice.js
+++ b/src/dice/FudgeDice.js
@@ -1,6 +1,6 @@
+import { generator } from '../utilities/NumberGenerator';
 import RollResult from '../results/RollResult';
 import StandardDice from './StandardDice';
-import { diceUtils } from '../utilities/utils';
 
 class FudgeDice extends StandardDice {
   constructor(notation, nonBlanks = 2, qty = 1, modifiers = null) {
@@ -33,11 +33,11 @@ class FudgeDice extends StandardDice {
 
     if (this.nonBlanks === 2) {
       // default fudge (2 of each non-blank) = 1d3 - 2
-      total = diceUtils.generateNumber(1, 3) - 2;
+      total = generator.integer(1, 3) - 2;
     } else if (this.nonBlanks === 1) {
       // only 1 of each non-blank
       // on 1d6 a roll of 1 = -1, 6 = +1, others = 0
-      const num = diceUtils.generateNumber(1, 6);
+      const num = generator.integer(1, 6);
       if (num === 1) {
         total = -1;
       } else if (num === 6) {

--- a/src/dice/StandardDice.js
+++ b/src/dice/StandardDice.js
@@ -1,5 +1,6 @@
 import { diceUtils } from '../utilities/utils';
 import ExplodeModifier from '../modifiers/ExplodeModifier';
+import { generator } from '../utilities/NumberGenerator';
 import RollResult from '../results/RollResult';
 import RollResults from '../results/RollResults';
 import ComparePoint from '../ComparePoint';
@@ -191,7 +192,7 @@ class StandardDice {
    * @returns {RollResult}
    */
   rollOnce() {
-    return new RollResult(diceUtils.generateNumber(this.min, this.max));
+    return new RollResult(generator.integer(this.min, this.max));
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import DiceRoller from './DiceRoller';
 import { diceUtils, exportFormats } from './utilities/utils';
 import * as Dice from './Dice';
 import * as Modifiers from './Modifiers';
+import * as NumberGenerator from './utilities/NumberGenerator';
 
 export {
   diceUtils,
@@ -12,5 +13,6 @@ export {
   DiceRoll,
   DiceRoller,
   Modifiers,
+  NumberGenerator,
   Parser,
 };

--- a/src/utilities/NumberGenerator.js
+++ b/src/utilities/NumberGenerator.js
@@ -1,0 +1,75 @@
+import {
+  browserCrypto, nodeCrypto, MersenneTwister19937, nativeMath, Random,
+} from 'random-js';
+
+const engineSymbol = Symbol('engine');
+const randomSymbol = Symbol('random');
+
+const engines = {
+  browserCrypto,
+  nodeCrypto,
+  MersenneTwister19937,
+  nativeMath,
+};
+
+class NumberGenerator {
+  constructor(engine = nativeMath) {
+    this.engine = engine || nativeMath;
+  }
+
+  /**
+   * Returns the current engine
+   *
+   * @returns {Engine}
+   */
+  get engine() {
+    return this[engineSymbol];
+  }
+
+  /**
+   * Sets the engine
+   *
+   * @param {Engine} engine
+   */
+  set engine(engine) {
+    if (engine && (typeof engine.next !== 'function')) {
+      throw new TypeError('engine must have function `next()`');
+    }
+
+    // set the engine and re-initialise the random engine
+    this[engineSymbol] = engine || nativeMath;
+    this[randomSymbol] = new Random(this[engineSymbol]);
+  }
+
+  /**
+   * Returns a random integer within the inclusive range `[min, max]`
+   *
+   * @param {number} min The minimum integer value, inclusive.
+   * @param {number} max The maximum integer value, inclusive.
+   *
+   * @returns {number}
+   */
+  integer(min, max) {
+    return this[randomSymbol].integer(min, max);
+  }
+
+  /**
+   * Returns a floating-point value within [min, max) or [min, max]
+   *
+   * @param {number} min The minimum floating-point value, inclusive.
+   * @param {number} max The maximum floating-point value.
+   * @param {boolean=} inclusive If true, `max` will be inclusive.
+   *
+   * @returns {number}
+   */
+  real(min, max, inclusive = false) {
+    return this[randomSymbol].real(min, max, inclusive);
+  }
+}
+
+const generator = new NumberGenerator();
+
+export {
+  engines,
+  generator,
+};

--- a/src/utilities/utils.js
+++ b/src/utilities/utils.js
@@ -1,3 +1,5 @@
+import { generator } from './NumberGenerator';
+
 /* eslint-disable */
 if (!Array.prototype.flat) {
   /**
@@ -92,16 +94,14 @@ const diceUtils = Object.freeze({
    * @param {number|string} min
    * @param {number|string} max
    * @returns {number}
+   *
+   * @deprecated use `NumberGenerator.generator.integer()` instead
    */
   generateNumber(min, max) {
-    const minNumber = min ? parseInt(min, 10) : 1;
-    const maxNumber = max ? parseInt(max, 10) : min;
+    // eslint-disable-next-line no-console
+    console.warn('diceUtils.generateNumber is deprecated, use NumberGenerator.generator.integer() instead');
 
-    if (maxNumber <= minNumber) {
-      return minNumber;
-    }
-
-    return Math.floor(Math.random() * (maxNumber - minNumber + 1) + minNumber);
+    return generator.integer(min, max);
   },
   /**
    * @returns {function(Array): number}

--- a/tests/utilities/NumberGenerator.test.js
+++ b/tests/utilities/NumberGenerator.test.js
@@ -1,0 +1,151 @@
+import { Random } from 'random-js';
+import { engines, generator } from '../../src/utilities/NumberGenerator';
+
+describe('NumberGenerator', () => {
+  describe('initialisation', () => {
+    test('model structure', () => {
+      expect(generator).toEqual(expect.objectContaining({
+        engine: expect.any(Object),
+        integer: expect.any(Function),
+        real: expect.any(Function),
+      }));
+    });
+  });
+
+  describe('engine', () => {
+    test('default engine is nativeMath (e.g. Math.round)', () => {
+      expect(generator.engine).toBe(engines.nativeMath);
+    });
+
+    test('can change engine', () => {
+      generator.engine = engines.nodeCrypto;
+      expect(generator.engine).toBe(engines.nodeCrypto);
+
+      generator.engine = engines.browserCrypto;
+      expect(generator.engine).toBe(engines.browserCrypto);
+
+      generator.engine = engines.nativeMath;
+      expect(generator.engine).toBe(engines.nativeMath);
+    });
+
+    test('setting to falsey defaults to nativeMath', () => {
+      generator.engine = false;
+      expect(generator.engine).toBe(engines.nativeMath);
+
+      generator.engine = null;
+      expect(generator.engine).toBe(engines.nativeMath);
+
+      generator.engine = undefined;
+      expect(generator.engine).toBe(engines.nativeMath);
+
+      generator.engine = 0;
+      expect(generator.engine).toBe(engines.nativeMath);
+    });
+
+    test('throws error if engine has no `next` method', () => {
+      expect(() => {
+        generator.engine = {};
+      }).toThrow(TypeError);
+
+      expect(() => {
+        generator.engine = 'foo';
+      }).toThrow(TypeError);
+
+      expect(() => {
+        generator.engine = true;
+      }).toThrow(TypeError);
+
+      expect(() => {
+        generator.engine = [];
+      }).toThrow(TypeError);
+
+      expect(() => {
+        generator.engine = 1;
+      }).toThrow(TypeError);
+
+      expect(() => {
+        generator.engine = 45;
+      }).toThrow(TypeError);
+    });
+  });
+
+  describe('generate', () => {
+    beforeEach(() => {
+      // reset to the default engine
+      generator.engine = engines.nativeMath;
+    });
+
+    describe('integer', () => {
+      test('calls `Random.integer()`', () => {
+        const spy = jest.spyOn(Random.prototype, 'integer')
+          .mockImplementationOnce(() => 3);
+
+        const result = generator.integer(1, 4);
+
+        expect(spy).toHaveBeenCalledWith(1, 4);
+        expect(result).toBe(3);
+      });
+
+      test('generates integer', () => {
+        const val = generator.integer(1, 4);
+
+        expect(Number.isInteger(val)).toBe(true);
+      });
+
+      test('generates integer even if `next` provides float', () => {
+        generator.engine = {
+          next() {
+            return 4.5;
+          },
+        };
+
+        const val = generator.integer(1, 4);
+
+        expect(Number.isInteger(val)).toBe(true);
+      });
+    });
+
+    describe('float', () => {
+      test('calls `Random.real()`', () => {
+        const spy = jest.spyOn(Random.prototype, 'real')
+          .mockImplementationOnce(() => 2.45);
+
+        const result = generator.real(1, 4);
+
+        expect(spy).toHaveBeenCalledWith(1, 4, false);
+        expect(result).toBe(2.45);
+      });
+
+      test('passes `inclusive` boolean to `Random.real()', () => {
+        const spy = jest.spyOn(Random.prototype, 'real')
+          .mockImplementation(() => 2.45);
+
+        let result = generator.real(1, 4, false);
+        expect(spy).toHaveBeenCalledWith(1, 4, false);
+        expect(result).toBe(2.45);
+
+        result = generator.real(1, 4, true);
+        expect(spy).toHaveBeenCalledWith(1, 4, true);
+        expect(result).toBe(2.45);
+      });
+
+      test('generates float', () => {
+        const val = generator.real(1, 4);
+
+        expect(Number.isInteger(val)).toBe(false);
+      });
+
+      test('generates float even if `next` provides integer', () => {
+        generator.engine = {
+          next() {
+            return 4;
+          },
+        };
+
+        const val = generator.real(1, 4);
+
+        expect(Number.isInteger(val)).toBe(false);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Allows users to use a different random number generator, instead of Math.Random.
Built in engines are `Math.Random`, `nodeCrypto`, `browserCrypto`, and `MersenneTwister19937`. Also allows for custom engines to be easily created and used.

Uses https://github.com/ckknight/random-js

Closes #141 