### PR TITLE
Set max iteration limit to explode and re-roll modifiers

### DIFF
--- a/src/modifiers/ExplodeModifier.js
+++ b/src/modifiers/ExplodeModifier.js
@@ -62,7 +62,8 @@ class ExplodeModifier extends ComparisonModifier {
         const subRolls = [roll];
         let compareValue = roll.value;
 
-        while (this.isComparePoint(compareValue)) {
+        // explode if the value matches the compare point, and we haven't reached the max iterations
+        for (let i = 0; (i < this.maxIterations) && this.isComparePoint(compareValue); i++) {
           const prevRoll = subRolls[subRolls.length - 1];
           // roll the dice
           const rollResult = _dice.rollOnce();

--- a/src/modifiers/Modifier.js
+++ b/src/modifiers/Modifier.js
@@ -28,6 +28,17 @@ class Modifier {
 
   /* eslint-disable class-methods-use-this */
   /**
+   * The maximum number of iterations that the modifier can be applied to a single die roll
+   *
+   * @returns {number}
+   */
+  get maxIterations() {
+    return 1000;
+  }
+  /* eslint-enable class-methods-use-this */
+
+  /* eslint-disable class-methods-use-this */
+  /**
    * Runs the modifier on the rolls
    *
    * @param {RollResults} results

--- a/src/modifiers/ReRollModifier.js
+++ b/src/modifiers/ReRollModifier.js
@@ -53,25 +53,23 @@ class ReRollModifier extends ComparisonModifier {
 
     results.rolls
       .map((roll) => {
-        let hasReRolled = false;
-
-        // if the die roll matches the compare point we re-roll. Unless we're only rolling once,
-        // we should re-roll if any consecutive rolls also match the CP
-        while (this.isComparePoint(roll.value) && (!this.once || !hasReRolled)) {
-          // roll the dice
+        // re-roll if the value matches the compare point and we haven't reached the max iterations,
+        // unless we're only rolling once and have already re-rolled
+        for (let i = 0; (i < this.maxIterations) && this.isComparePoint(roll.value); i++) {
+          // re-roll the dice
           const rollResult = _dice.rollOnce();
 
-          // update the roll value (Unlike exploding, the original value if not kept)
+          // update the roll value (Unlike exploding, the original value is not kept)
           // eslint-disable-next-line no-param-reassign
           roll.value = rollResult.value;
 
-          // increment the roll count so we only roll once when required
-          hasReRolled = true;
-        }
-
-        // add the re-roll modifier flag outside the loop, otherwise we get duplicate flags
-        if (hasReRolled) {
+          // add the re-roll modifier flag
           roll.modifiers.add(`re-roll${this.once ? '-once' : ''}`);
+
+          // stop the loop if we're only re-rolling once
+          if (this.once) {
+            break;
+          }
         }
 
         return roll;


### PR DESCRIPTION
This stops infinite loops when exploding / re-rolling dice. It's part of the requirement for #137