### PR TITLE
Feature/158 warhammer style min modifier

### DIFF
--- a/src/Modifiers.js
+++ b/src/Modifiers.js
@@ -4,6 +4,7 @@ import CriticalSuccessModifier from './modifiers/CriticalSuccessModifier';
 import DropModifier from './modifiers/DropModifier';
 import ExplodeModifier from './modifiers/ExplodeModifier';
 import KeepModifier from './modifiers/KeepModifier';
+import MaxModifier from './modifiers/MaxModifier';
 import MinModifier from './modifiers/MinModifier';
 import ReRollModifier from './modifiers/ReRollModifier';
 import SortingModifier from './modifiers/SortingModifier';
@@ -16,6 +17,7 @@ export {
   DropModifier,
   ExplodeModifier,
   KeepModifier,
+  MaxModifier,
   MinModifier,
   ReRollModifier,
   SortingModifier,

--- a/src/Modifiers.js
+++ b/src/Modifiers.js
@@ -4,6 +4,7 @@ import CriticalSuccessModifier from './modifiers/CriticalSuccessModifier';
 import DropModifier from './modifiers/DropModifier';
 import ExplodeModifier from './modifiers/ExplodeModifier';
 import KeepModifier from './modifiers/KeepModifier';
+import MinModifier from './modifiers/MinModifier';
 import ReRollModifier from './modifiers/ReRollModifier';
 import SortingModifier from './modifiers/SortingModifier';
 import TargetModifier from './modifiers/TargetModifier';
@@ -15,6 +16,7 @@ export {
   DropModifier,
   ExplodeModifier,
   KeepModifier,
+  MinModifier,
   ReRollModifier,
   SortingModifier,
   TargetModifier,

--- a/src/modifiers/CriticalFailureModifier.js
+++ b/src/modifiers/CriticalFailureModifier.js
@@ -5,7 +5,7 @@ class CriticalFailureModifier extends ComparisonModifier {
     super(notation, comparePoint);
 
     // set the modifier's sort order
-    this.order = 7;
+    this.order = 8;
   }
 
   /**
@@ -18,7 +18,7 @@ class CriticalFailureModifier extends ComparisonModifier {
    */
   run(results, _dice) {
     results.rolls
-      .map((roll) => {
+      .forEach((roll) => {
         // add the modifier flag
         if (this.isComparePoint(roll.value)) {
           roll.modifiers.add('critical-failure');

--- a/src/modifiers/CriticalFailureModifier.js
+++ b/src/modifiers/CriticalFailureModifier.js
@@ -5,7 +5,7 @@ class CriticalFailureModifier extends ComparisonModifier {
     super(notation, comparePoint);
 
     // set the modifier's sort order
-    this.order = 8;
+    this.order = 9;
   }
 
   /**

--- a/src/modifiers/CriticalSuccessModifier.js
+++ b/src/modifiers/CriticalSuccessModifier.js
@@ -5,7 +5,7 @@ class CriticalSuccessModifier extends ComparisonModifier {
     super(notation, comparePoint);
 
     // set the modifier's sort order
-    this.order = 6;
+    this.order = 7;
   }
 
   /**
@@ -19,7 +19,7 @@ class CriticalSuccessModifier extends ComparisonModifier {
   run(results, _dice) {
     // loop through each roll and see if it's a critical success
     results.rolls
-      .map((roll) => {
+      .forEach((roll) => {
         // add the modifier flag
         if (this.isComparePoint(roll.value)) {
           roll.modifiers.add('critical-success');

--- a/src/modifiers/CriticalSuccessModifier.js
+++ b/src/modifiers/CriticalSuccessModifier.js
@@ -5,7 +5,7 @@ class CriticalSuccessModifier extends ComparisonModifier {
     super(notation, comparePoint);
 
     // set the modifier's sort order
-    this.order = 7;
+    this.order = 8;
   }
 
   /**

--- a/src/modifiers/DropModifier.js
+++ b/src/modifiers/DropModifier.js
@@ -5,7 +5,7 @@ class DropModifier extends KeepModifier {
     super(notation, end, qty);
 
     // set the modifier's sort order
-    this.order = 4;
+    this.order = 5;
   }
 
   /**

--- a/src/modifiers/DropModifier.js
+++ b/src/modifiers/DropModifier.js
@@ -5,7 +5,7 @@ class DropModifier extends KeepModifier {
     super(notation, end, qty);
 
     // set the modifier's sort order
-    this.order = 5;
+    this.order = 6;
   }
 
   /**

--- a/src/modifiers/ExplodeModifier.js
+++ b/src/modifiers/ExplodeModifier.js
@@ -20,7 +20,7 @@ class ExplodeModifier extends ComparisonModifier {
     this[penetrateSymbol] = !!penetrate;
 
     // set the modifier's sort order
-    this.order = 2;
+    this.order = 3;
   }
 
   /**

--- a/src/modifiers/ExplodeModifier.js
+++ b/src/modifiers/ExplodeModifier.js
@@ -20,7 +20,7 @@ class ExplodeModifier extends ComparisonModifier {
     this[penetrateSymbol] = !!penetrate;
 
     // set the modifier's sort order
-    this.order = 1;
+    this.order = 2;
   }
 
   /**

--- a/src/modifiers/KeepModifier.js
+++ b/src/modifiers/KeepModifier.js
@@ -18,7 +18,7 @@ class KeepModifier extends Modifier {
     this.qty = (qty || (qty === 0)) ? qty : 1;
 
     // set the modifier's sort order
-    this.order = 4;
+    this.order = 5;
   }
 
   /**

--- a/src/modifiers/KeepModifier.js
+++ b/src/modifiers/KeepModifier.js
@@ -18,7 +18,7 @@ class KeepModifier extends Modifier {
     this.qty = (qty || (qty === 0)) ? qty : 1;
 
     // set the modifier's sort order
-    this.order = 3;
+    this.order = 4;
   }
 
   /**

--- a/src/modifiers/MaxModifier.js
+++ b/src/modifiers/MaxModifier.js
@@ -1,43 +1,43 @@
 import Modifier from './Modifier';
 import { diceUtils } from '../utilities/utils';
 
-const minSymbol = Symbol('min');
+const maxSymbol = Symbol('max');
 
-class MinModifier extends Modifier {
+class MaxModifier extends Modifier {
   /**
    *
    * @param {string} notation
-   * @param {Number} min
+   * @param {number} max
    */
-  constructor(notation, min) {
+  constructor(notation, max) {
     super(notation);
 
-    this.min = min;
+    this.max = max;
 
     // set the modifier's sort order
-    this.order = 1;
+    this.order = 2;
   }
 
   /**
-   * Returns the minimum value
+   * Returns the maximum value
    *
    * @returns {Number}
    */
-  get min() {
-    return this[minSymbol];
+  get max() {
+    return this[maxSymbol];
   }
 
   /**
-   * Sets the minimum value
+   * Sets the maximum value
    *
    * @param value
    */
-  set min(value) {
+  set max(value) {
     if (!diceUtils.isNumeric(value)) {
-      throw new TypeError('min must be a number');
+      throw new TypeError('max must be a number');
     }
 
-    this[minSymbol] = parseFloat(value);
+    this[maxSymbol] = parseFloat(value);
   }
 
   /**
@@ -54,9 +54,9 @@ class MinModifier extends Modifier {
     parsedResults.rolls = results.rolls.map((roll) => {
       const parsedRoll = roll;
 
-      if (roll.value < this.min) {
-        parsedRoll.value = this.min;
-        parsedRoll.modifiers.add('min');
+      if (roll.value > this.max) {
+        parsedRoll.value = this.max;
+        parsedRoll.modifiers.add('max');
       }
 
       return parsedRoll;
@@ -71,15 +71,15 @@ class MinModifier extends Modifier {
    * @returns {{}}
    */
   toJSON() {
-    const { min } = this;
+    const { max } = this;
 
     return Object.assign(
       super.toJSON(),
       {
-        min,
+        max,
       },
     );
   }
 }
 
-export default MinModifier;
+export default MaxModifier;

--- a/src/modifiers/MinModifier.js
+++ b/src/modifiers/MinModifier.js
@@ -1,0 +1,80 @@
+import Modifier from './Modifier';
+import { diceUtils } from '../utilities/utils';
+
+const minSymbol = Symbol('min');
+
+class MinModifier extends Modifier {
+  constructor(notation, min) {
+    super(notation);
+
+    this.min = min;
+
+    // set the modifier's sort order
+    this.order = 1;
+  }
+
+  /**
+   * Returns the minimum value
+   *
+   * @returns {Number}
+   */
+  get min() {
+    return this[minSymbol];
+  }
+
+  /**
+   * Sets the minimum value
+   *
+   * @param value
+   */
+  set min(value) {
+    if (!diceUtils.isNumeric(value)) {
+      throw new TypeError('min must be a number');
+    }
+
+    this[minSymbol] = parseFloat(value);
+  }
+
+  /**
+   * Runs the modifier on the rolls
+   *
+   * @param {RollResults} results
+   * @param {StandardDice} _dice
+   *
+   * @returns {RollResults}
+   */
+  run(results, _dice) {
+    const parsedResults = results;
+
+    parsedResults.rolls = results.rolls.map((roll) => {
+      const parsedRoll = roll;
+
+      if (roll.value < this.min) {
+        parsedRoll.value = this.min;
+        parsedRoll.modifiers.add('min');
+      }
+
+      return parsedRoll;
+    });
+
+    return parsedResults;
+  }
+
+  /**
+   * Returns an object for JSON serialising
+   *
+   * @returns {{}}
+   */
+  toJSON() {
+    const { min } = this;
+
+    return Object.assign(
+      super.toJSON(),
+      {
+        min,
+      },
+    );
+  }
+}
+
+export default MinModifier;

--- a/src/modifiers/ReRollModifier.js
+++ b/src/modifiers/ReRollModifier.js
@@ -16,7 +16,7 @@ class ReRollModifier extends ComparisonModifier {
     this.once = !!once;
 
     // set the modifier's sort order
-    this.order = 2;
+    this.order = 3;
   }
 
   /**

--- a/src/modifiers/ReRollModifier.js
+++ b/src/modifiers/ReRollModifier.js
@@ -16,7 +16,7 @@ class ReRollModifier extends ComparisonModifier {
     this.once = !!once;
 
     // set the modifier's sort order
-    this.order = 3;
+    this.order = 4;
   }
 
   /**

--- a/src/modifiers/SortingModifier.js
+++ b/src/modifiers/SortingModifier.js
@@ -14,7 +14,7 @@ class SortingModifier extends Modifier {
     this.direction = direction || 'a';
 
     // set the modifier's sort order
-    this.order = 8;
+    this.order = 9;
   }
 
   /**

--- a/src/modifiers/SortingModifier.js
+++ b/src/modifiers/SortingModifier.js
@@ -14,7 +14,7 @@ class SortingModifier extends Modifier {
     this.direction = direction || 'a';
 
     // set the modifier's sort order
-    this.order = 9;
+    this.order = 10;
   }
 
   /**

--- a/src/modifiers/TargetModifier.js
+++ b/src/modifiers/TargetModifier.js
@@ -17,7 +17,7 @@ class TargetModifier extends ComparisonModifier {
     this.failureComparePoint = failureCP;
 
     // set the modifier's sort order
-    this.order = 6;
+    this.order = 7;
   }
 
   /**

--- a/src/modifiers/TargetModifier.js
+++ b/src/modifiers/TargetModifier.js
@@ -17,7 +17,7 @@ class TargetModifier extends ComparisonModifier {
     this.failureComparePoint = failureCP;
 
     // set the modifier's sort order
-    this.order = 5;
+    this.order = 6;
   }
 
   /**

--- a/src/parser/grammars/grammar.pegjs
+++ b/src/parser/grammars/grammar.pegjs
@@ -50,7 +50,16 @@ FudgeDie
 
 // Modifiers
 
-Modifier = ExplodeModifier / TargetModifier / DropModifier / KeepModifier / ReRollModifier / CriticalSuccessModifier / CriticalFailureModifier / SortingModifier
+Modifier
+  = ExplodeModifier
+  / TargetModifier
+  / DropModifier
+  / KeepModifier
+  / ReRollModifier
+  / CriticalSuccessModifier
+  / CriticalFailureModifier
+  / SortingModifier
+  / MinModifier
 
 // Explode, Penetrate, Compound modifier
 ExplodeModifier
@@ -74,6 +83,12 @@ DropModifier
 KeepModifier
   = "k" end:[lh]? qty:IntegerNumber {
     return new Modifiers.KeepModifier(text(), end || 'h', qty);
+  }
+
+// Minimum roll value
+MinModifier
+  = "min" min:FloatNumber {
+    return new Modifiers.MinModifier(text(), min);
   }
 
 // Re-rolling Dice (Including Re-roll Once)

--- a/src/parser/grammars/grammar.pegjs
+++ b/src/parser/grammars/grammar.pegjs
@@ -59,6 +59,7 @@ Modifier
   / CriticalSuccessModifier
   / CriticalFailureModifier
   / SortingModifier
+  / MaxModifier
   / MinModifier
 
 // Explode, Penetrate, Compound modifier
@@ -83,6 +84,12 @@ DropModifier
 KeepModifier
   = "k" end:[lh]? qty:IntegerNumber {
     return new Modifiers.KeepModifier(text(), end || 'h', qty);
+  }
+
+// Maximum roll value
+MaxModifier
+  = "max" max:FloatNumber {
+    return new Modifiers.MaxModifier(text(), max);
   }
 
 // Minimum roll value

--- a/src/results/RollResult.js
+++ b/src/results/RollResult.js
@@ -108,6 +108,9 @@ class RollResult {
         case 'drop':
           flag = 'd';
           break;
+        case 'min':
+          flag = '^';
+          break;
         case 'penetrate':
           flag = 'p';
           break;

--- a/src/results/RollResult.js
+++ b/src/results/RollResult.js
@@ -108,6 +108,9 @@ class RollResult {
         case 'drop':
           flag = 'd';
           break;
+        case 'max':
+          flag = 'v';
+          break;
         case 'min':
           flag = '^';
           break;

--- a/tests/modifiers/KeepModifier.test.js
+++ b/tests/modifiers/KeepModifier.test.js
@@ -180,8 +180,9 @@ describe('KeepModifier', () => {
   });
 
   describe('Run', () => {
-    let mod; let die; let
-      results;
+    let mod;
+    let die;
+    let results;
 
     beforeEach(() => {
       results = new RollResults([

--- a/tests/modifiers/MaxModifier.test.js
+++ b/tests/modifiers/MaxModifier.test.js
@@ -1,0 +1,192 @@
+import MaxModifier from '../../src/modifiers/MaxModifier';
+import Modifier from '../../src/modifiers/Modifier';
+import RequiredArgumentError from '../../src/exceptions/RequiredArgumentErrorError';
+import StandardDice from '../../src/dice/StandardDice';
+import RollResults from '../../src/results/RollResults';
+
+describe('MaxModifier', () => {
+  let mod;
+
+  beforeEach(() => {
+    mod = new MaxModifier('max3', 3);
+  });
+
+  describe('Initialisation', () => {
+    test('model structure', () => {
+      expect(mod).toBeInstanceOf(MaxModifier);
+      expect(mod).toBeInstanceOf(Modifier);
+
+      expect(mod).toEqual(expect.objectContaining({
+        max: 3,
+        name: 'MaxModifier',
+        notation: 'max3',
+        run: expect.any(Function),
+        toJSON: expect.any(Function),
+        toString: expect.any(Function),
+      }));
+    });
+
+    test('constructor requires notation', () => {
+      expect(() => {
+        new MaxModifier();
+      }).toThrow(RequiredArgumentError);
+
+      expect(() => {
+        new MaxModifier(false);
+      }).toThrow(RequiredArgumentError);
+
+      expect(() => {
+        new MaxModifier(null);
+      }).toThrow(RequiredArgumentError);
+
+      expect(() => {
+        new MaxModifier(undefined);
+      }).toThrow(RequiredArgumentError);
+    });
+
+    test('constructor requires max', () => {
+      expect(() => {
+        new MaxModifier('max3');
+      }).toThrow(TypeError);
+
+      expect(() => {
+        new MaxModifier('max3', false);
+      }).toThrow(TypeError);
+
+      expect(() => {
+        new MaxModifier('max3', null);
+      }).toThrow(TypeError);
+
+      expect(() => {
+        new MaxModifier('max3', undefined);
+      }).toThrow(TypeError);
+    });
+  });
+
+  describe('Max', () => {
+    test('can be changed', () => {
+      expect(mod.max).toBe(3);
+
+      mod.max = 1;
+      expect(mod.max).toBe(1);
+
+      mod.max = 23;
+      expect(mod.max).toBe(23);
+    });
+
+    test('must be numeric', () => {
+      expect(() => {
+        mod.max = 'foo';
+      }).toThrow(TypeError);
+
+      expect(() => {
+        mod.max = [];
+      }).toThrow(TypeError);
+
+      expect(() => {
+        mod.max = { max: 3 };
+      }).toThrow(TypeError);
+    });
+
+    test('can be float', () => {
+      mod.max = 4.5;
+      expect(mod.max).toBeCloseTo(4.5);
+
+      mod.max = 300.6579;
+      expect(mod.max).toBeCloseTo(300.6579);
+    });
+
+    test('can be negative', () => {
+      mod.max = -10;
+      expect(mod.max).toBe(-10);
+
+      mod.max = -46.2;
+      expect(mod.max).toBeCloseTo(-46.2);
+    });
+  });
+
+  describe('Output', () => {
+    test('JSON output is correct', () => {
+      expect(JSON.parse(JSON.stringify(mod))).toEqual({
+        max: 3,
+        name: 'MaxModifier',
+        notation: 'max3',
+        type: 'modifier',
+      });
+    });
+
+    test('toString output is correct', () => {
+      expect(mod.toString()).toEqual('max3');
+    });
+  });
+
+  describe('Run', () => {
+    let die;
+    let results;
+
+    beforeEach(() => {
+      results = new RollResults([
+        1, 4, 2, 1, 6,
+      ]);
+      die = new StandardDice('5d10', 10, 5);
+    });
+
+    test('returns RollResults object', () => {
+      expect(mod.run(results, die)).toBe(results);
+    });
+
+    test('rolls lower than max are changed to max', () => {
+      const { rolls } = mod.run(results, die);
+
+      expect(rolls.length).toBe(5);
+
+      // check the first roll
+      expect(rolls[0].initialValue).toBe(1);
+      expect(rolls[0].calculationValue).toBe(1);
+      expect(rolls[0].value).toBe(1);
+      expect(rolls[0].useInTotal).toBe(true);
+      expect(rolls[0].modifierFlags).toEqual('');
+      expect(rolls[0].modifiers).toEqual(new Set());
+
+      // check the second roll
+      expect(rolls[1].initialValue).toBe(4);
+      expect(rolls[1].calculationValue).toBe(3);
+      expect(rolls[1].value).toBe(3);
+      expect(rolls[1].useInTotal).toBe(true);
+      expect(rolls[1].modifierFlags).toEqual('v');
+      expect(rolls[1].modifiers).toEqual(new Set(['max']));
+
+      // check the third roll
+      expect(rolls[2].initialValue).toBe(2);
+      expect(rolls[2].calculationValue).toBe(2);
+      expect(rolls[2].value).toBe(2);
+      expect(rolls[2].useInTotal).toBe(true);
+      expect(rolls[2].modifierFlags).toEqual('');
+      expect(rolls[2].modifiers).toEqual(new Set());
+
+      // check the fourth roll
+      expect(rolls[3].initialValue).toBe(1);
+      expect(rolls[3].calculationValue).toBe(1);
+      expect(rolls[3].value).toBe(1);
+      expect(rolls[3].useInTotal).toBe(true);
+      expect(rolls[3].modifierFlags).toEqual('');
+      expect(rolls[3].modifiers).toEqual(new Set());
+
+      // check the fifth roll
+      expect(rolls[4].initialValue).toBe(6);
+      expect(rolls[4].calculationValue).toBe(3);
+      expect(rolls[4].value).toBe(3);
+      expect(rolls[4].useInTotal).toBe(true);
+      expect(rolls[4].modifierFlags).toEqual('v');
+      expect(rolls[4].modifiers).toEqual(new Set(['max']));
+    });
+  });
+
+  describe('Readonly properties', () => {
+    test('cannot change name value', () => {
+      expect(() => {
+        mod.name = 'Foo';
+      }).toThrow(TypeError);
+    });
+  });
+});

--- a/tests/modifiers/MinModifier.test.js
+++ b/tests/modifiers/MinModifier.test.js
@@ -1,0 +1,192 @@
+import MinModifier from '../../src/modifiers/MinModifier';
+import Modifier from '../../src/modifiers/Modifier';
+import RequiredArgumentError from '../../src/exceptions/RequiredArgumentErrorError';
+import StandardDice from '../../src/dice/StandardDice';
+import RollResults from '../../src/results/RollResults';
+
+describe('MinModifier', () => {
+  let mod;
+
+  beforeEach(() => {
+    mod = new MinModifier('min3', 3);
+  });
+
+  describe('Initialisation', () => {
+    test('model structure', () => {
+      expect(mod).toBeInstanceOf(MinModifier);
+      expect(mod).toBeInstanceOf(Modifier);
+
+      expect(mod).toEqual(expect.objectContaining({
+        min: 3,
+        name: 'MinModifier',
+        notation: 'min3',
+        run: expect.any(Function),
+        toJSON: expect.any(Function),
+        toString: expect.any(Function),
+      }));
+    });
+
+    test('constructor requires notation', () => {
+      expect(() => {
+        new MinModifier();
+      }).toThrow(RequiredArgumentError);
+
+      expect(() => {
+        new MinModifier(false);
+      }).toThrow(RequiredArgumentError);
+
+      expect(() => {
+        new MinModifier(null);
+      }).toThrow(RequiredArgumentError);
+
+      expect(() => {
+        new MinModifier(undefined);
+      }).toThrow(RequiredArgumentError);
+    });
+
+    test('constructor requires min', () => {
+      expect(() => {
+        new MinModifier('min3');
+      }).toThrow(TypeError);
+
+      expect(() => {
+        new MinModifier('min3', false);
+      }).toThrow(TypeError);
+
+      expect(() => {
+        new MinModifier('min3', null);
+      }).toThrow(TypeError);
+
+      expect(() => {
+        new MinModifier('min3', undefined);
+      }).toThrow(TypeError);
+    });
+  });
+
+  describe('Min', () => {
+    test('can be changed', () => {
+      expect(mod.min).toBe(3);
+
+      mod.min = 1;
+      expect(mod.min).toBe(1);
+
+      mod.min = 23;
+      expect(mod.min).toBe(23);
+    });
+
+    test('must be numeric', () => {
+      expect(() => {
+        mod.min = 'foo';
+      }).toThrow(TypeError);
+
+      expect(() => {
+        mod.min = [];
+      }).toThrow(TypeError);
+
+      expect(() => {
+        mod.min = { min: 3 };
+      }).toThrow(TypeError);
+    });
+
+    test('can be float', () => {
+      mod.min = 4.5;
+      expect(mod.min).toBeCloseTo(4.5);
+
+      mod.min = 300.6579;
+      expect(mod.min).toBeCloseTo(300.6579);
+    });
+
+    test('can be negative', () => {
+      mod.min = -10;
+      expect(mod.min).toBe(-10);
+
+      mod.min = -46.2;
+      expect(mod.min).toBeCloseTo(-46.2);
+    });
+  });
+
+  describe('Output', () => {
+    test('JSON output is correct', () => {
+      expect(JSON.parse(JSON.stringify(mod))).toEqual({
+        min: 3,
+        name: 'MinModifier',
+        notation: 'min3',
+        type: 'modifier',
+      });
+    });
+
+    test('toString output is correct', () => {
+      expect(mod.toString()).toEqual('min3');
+    });
+  });
+
+  describe('Run', () => {
+    let die;
+    let results;
+
+    beforeEach(() => {
+      results = new RollResults([
+        1, 4, 2, 1, 6,
+      ]);
+      die = new StandardDice('5d10', 10, 5);
+    });
+
+    test('returns RollResults object', () => {
+      expect(mod.run(results, die)).toBe(results);
+    });
+
+    test('rolls lower than min are changed to min', () => {
+      const { rolls } = mod.run(results, die);
+
+      expect(rolls.length).toBe(5);
+
+      // check the first roll
+      expect(rolls[0].initialValue).toBe(1);
+      expect(rolls[0].calculationValue).toBe(3);
+      expect(rolls[0].value).toBe(3);
+      expect(rolls[0].useInTotal).toBe(true);
+      expect(rolls[0].modifierFlags).toEqual('^');
+      expect(rolls[0].modifiers).toEqual(new Set(['min']));
+
+      // check the second roll
+      expect(rolls[1].initialValue).toBe(4);
+      expect(rolls[1].calculationValue).toBe(4);
+      expect(rolls[1].value).toBe(4);
+      expect(rolls[1].useInTotal).toBe(true);
+      expect(rolls[1].modifierFlags).toEqual('');
+      expect(rolls[1].modifiers).toEqual(new Set());
+
+      // check the third roll
+      expect(rolls[2].initialValue).toBe(2);
+      expect(rolls[2].calculationValue).toBe(3);
+      expect(rolls[2].value).toBe(3);
+      expect(rolls[2].useInTotal).toBe(true);
+      expect(rolls[2].modifierFlags).toEqual('^');
+      expect(rolls[2].modifiers).toEqual(new Set(['min']));
+
+      // check the fourth roll
+      expect(rolls[3].initialValue).toBe(1);
+      expect(rolls[3].calculationValue).toBe(3);
+      expect(rolls[3].value).toBe(3);
+      expect(rolls[3].useInTotal).toBe(true);
+      expect(rolls[3].modifierFlags).toEqual('^');
+      expect(rolls[3].modifiers).toEqual(new Set(['min']));
+
+      // check the fifth roll
+      expect(rolls[4].initialValue).toBe(6);
+      expect(rolls[4].calculationValue).toBe(6);
+      expect(rolls[4].value).toBe(6);
+      expect(rolls[4].useInTotal).toBe(true);
+      expect(rolls[4].modifierFlags).toEqual('');
+      expect(rolls[4].modifiers).toEqual(new Set());
+    });
+  });
+
+  describe('Readonly properties', () => {
+    test('cannot change name value', () => {
+      expect(() => {
+        mod.name = 'Foo';
+      }).toThrow(TypeError);
+    });
+  });
+});

--- a/tests/parser/Parser.test.js
+++ b/tests/parser/Parser.test.js
@@ -1,15 +1,16 @@
-import Parser from '../../src/parser/Parser';
 import { FudgeDice, PercentileDice, StandardDice } from '../../src/Dice';
 import CriticalFailureModifier from '../../src/modifiers/CriticalFailureModifier';
 import CriticalSuccessModifier from '../../src/modifiers/CriticalSuccessModifier';
 import DropModifier from '../../src/modifiers/DropModifier';
 import ExplodeModifier from '../../src/modifiers/ExplodeModifier';
-import ReRollModifier from '../../src/modifiers/ReRollModifier';
 import KeepModifier from '../../src/modifiers/KeepModifier';
+import MinModifier from '../../src/modifiers/MinModifier';
 import * as parser from '../../src/parser/grammars/grammar';
+import Parser from '../../src/parser/Parser';
 import SortingModifier from '../../src/modifiers/SortingModifier';
 import TargetModifier from '../../src/modifiers/TargetModifier';
 import RequiredArgumentError from '../../src/exceptions/RequiredArgumentErrorError';
+import ReRollModifier from '../../src/modifiers/ReRollModifier';
 
 describe('Parser', () => {
   describe('Initialisation', () => {
@@ -685,6 +686,87 @@ describe('Parser', () => {
             end: 'l',
             qty: 3,
           }));
+        });
+      });
+
+      describe('Min', () => {
+        test('min for `2d6min3`', () => {
+          const parsed = Parser.parse('2d6min3');
+
+          expect(parsed).toBeInstanceOf(Array);
+          expect(parsed).toHaveLength(1);
+          expect(parsed[0]).toBeInstanceOf(StandardDice);
+
+          expect(parsed[0].notation).toEqual('2d6');
+          expect(parsed[0].sides).toEqual(6);
+          expect(parsed[0].qty).toEqual(2);
+
+          expect(parsed[0].modifiers.has('MinModifier')).toBe(true);
+
+          const mod = parsed[0].modifiers.get('MinModifier');
+          expect(mod).toBeInstanceOf(MinModifier);
+          expect(mod.toJSON()).toEqual(expect.objectContaining({
+            min: 3,
+            notation: 'min3',
+          }));
+        });
+
+        test('min for `4d20min-12`', () => {
+          const parsed = Parser.parse('4d20min-12');
+
+          expect(parsed).toBeInstanceOf(Array);
+          expect(parsed).toHaveLength(1);
+          expect(parsed[0]).toBeInstanceOf(StandardDice);
+
+          expect(parsed[0].notation).toEqual('4d20');
+          expect(parsed[0].sides).toEqual(20);
+          expect(parsed[0].qty).toEqual(4);
+
+          expect(parsed[0].modifiers.has('MinModifier')).toBe(true);
+
+          const mod = parsed[0].modifiers.get('MinModifier');
+          expect(mod).toBeInstanceOf(MinModifier);
+          expect(mod.toJSON()).toEqual(expect.objectContaining({
+            min: -12,
+            notation: 'min-12',
+          }));
+        });
+
+        test('min for `6d%min50.45`', () => {
+          const parsed = Parser.parse('6d%min50.45');
+
+          expect(parsed).toBeInstanceOf(Array);
+          expect(parsed).toHaveLength(1);
+          expect(parsed[0]).toBeInstanceOf(StandardDice);
+
+          expect(parsed[0].notation).toEqual('6d%');
+          expect(parsed[0].sides).toEqual('%');
+          expect(parsed[0].qty).toEqual(6);
+
+          expect(parsed[0].modifiers.has('MinModifier')).toBe(true);
+
+          const mod = parsed[0].modifiers.get('MinModifier');
+          expect(mod).toBeInstanceOf(MinModifier);
+          expect(mod.toJSON()).toEqual(expect.objectContaining({
+            min: 50.45,
+            notation: 'min50.45',
+          }));
+        });
+
+        test('throws error if no min value', () => {
+          expect(() => {
+            Parser.parse('d6min');
+          }).toThrow(parser.SyntaxError);
+        });
+
+        test('throws error if invalid min value', () => {
+          expect(() => {
+            Parser.parse('d6minfoo');
+          }).toThrow(parser.SyntaxError);
+
+          expect(() => {
+            Parser.parse('d6mind6');
+          }).toThrow(parser.SyntaxError);
         });
       });
 

--- a/tests/parser/Parser.test.js
+++ b/tests/parser/Parser.test.js
@@ -4,6 +4,7 @@ import CriticalSuccessModifier from '../../src/modifiers/CriticalSuccessModifier
 import DropModifier from '../../src/modifiers/DropModifier';
 import ExplodeModifier from '../../src/modifiers/ExplodeModifier';
 import KeepModifier from '../../src/modifiers/KeepModifier';
+import MaxModifier from '../../src/modifiers/MaxModifier';
 import MinModifier from '../../src/modifiers/MinModifier';
 import * as parser from '../../src/parser/grammars/grammar';
 import Parser from '../../src/parser/Parser';
@@ -686,6 +687,87 @@ describe('Parser', () => {
             end: 'l',
             qty: 3,
           }));
+        });
+      });
+
+      describe('Max', () => {
+        test('max for `2d6max3`', () => {
+          const parsed = Parser.parse('2d6max3');
+
+          expect(parsed).toBeInstanceOf(Array);
+          expect(parsed).toHaveLength(1);
+          expect(parsed[0]).toBeInstanceOf(StandardDice);
+
+          expect(parsed[0].notation).toEqual('2d6');
+          expect(parsed[0].sides).toEqual(6);
+          expect(parsed[0].qty).toEqual(2);
+
+          expect(parsed[0].modifiers.has('MaxModifier')).toBe(true);
+
+          const mod = parsed[0].modifiers.get('MaxModifier');
+          expect(mod).toBeInstanceOf(MaxModifier);
+          expect(mod.toJSON()).toEqual(expect.objectContaining({
+            max: 3,
+            notation: 'max3',
+          }));
+        });
+
+        test('max for `4d20max-12`', () => {
+          const parsed = Parser.parse('4d20max-12');
+
+          expect(parsed).toBeInstanceOf(Array);
+          expect(parsed).toHaveLength(1);
+          expect(parsed[0]).toBeInstanceOf(StandardDice);
+
+          expect(parsed[0].notation).toEqual('4d20');
+          expect(parsed[0].sides).toEqual(20);
+          expect(parsed[0].qty).toEqual(4);
+
+          expect(parsed[0].modifiers.has('MaxModifier')).toBe(true);
+
+          const mod = parsed[0].modifiers.get('MaxModifier');
+          expect(mod).toBeInstanceOf(MaxModifier);
+          expect(mod.toJSON()).toEqual(expect.objectContaining({
+            max: -12,
+            notation: 'max-12',
+          }));
+        });
+
+        test('max for `6d%max50.45`', () => {
+          const parsed = Parser.parse('6d%max50.45');
+
+          expect(parsed).toBeInstanceOf(Array);
+          expect(parsed).toHaveLength(1);
+          expect(parsed[0]).toBeInstanceOf(StandardDice);
+
+          expect(parsed[0].notation).toEqual('6d%');
+          expect(parsed[0].sides).toEqual('%');
+          expect(parsed[0].qty).toEqual(6);
+
+          expect(parsed[0].modifiers.has('MaxModifier')).toBe(true);
+
+          const mod = parsed[0].modifiers.get('MaxModifier');
+          expect(mod).toBeInstanceOf(MaxModifier);
+          expect(mod.toJSON()).toEqual(expect.objectContaining({
+            max: 50.45,
+            notation: 'max50.45',
+          }));
+        });
+
+        test('throws error if no max value', () => {
+          expect(() => {
+            Parser.parse('d6max');
+          }).toThrow(parser.SyntaxError);
+        });
+
+        test('throws error if invalid max value', () => {
+          expect(() => {
+            Parser.parse('d6maxfoo');
+          }).toThrow(parser.SyntaxError);
+
+          expect(() => {
+            Parser.parse('d6maxd6');
+          }).toThrow(parser.SyntaxError);
         });
       });
 


### PR DESCRIPTION
Add two new modifiers; `min` and `max`, for forcing dice rolls to have a specified min or max value.

Closes #158