### PR TITLE
Feature/173 dont require full import require path

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,13 @@
   "module": "./lib/esm/bundle.js",
   "browser": "./lib/umd/bundle.js",
   "exports": {
-    "import": "./lib/esm/bundle.js",
-    "require": "./lib/umd/bundle.js"
+    ".": {
+      "import": "./lib/esm/bundle.js",
+      "require": "./lib/umd/bundle.js"
+    },
+    "./lib/umd/bundle.js": {
+      "require": "./lib/umd/bundle.js"
+    }
   },
   "types": "./types/index.d.ts",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,15 @@
   "author": "GreenImp <info@greenimp.co.uk> (http://greenimp.co.uk)",
   "version": "4.3.1",
   "license": "MIT",
-  "main": "lib/esm/bundle.js",
-  "module": "lib/esm/bundle.js",
-  "browser": "lib/umd/bundle.js",
-  "types": "types/index.d.ts",
+  "type": "module",
+  "main": "./lib/esm/bundle.js",
+  "module": "./lib/esm/bundle.js",
+  "browser": "./lib/umd/bundle.js",
+  "exports": {
+    "import": "./lib/esm/bundle.js",
+    "require": "./lib/umd/bundle.js"
+  },
+  "types": "./types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/GreenImp/rpg-dice-roller.git"
@@ -73,6 +78,5 @@
     "test:coverage": "npm run pretest && jest --coverage",
     "test:coveralls": "npm run test:coverage && coveralls < coverage/lcov.info",
     "prepublishOnly": "npm test && npm run build:prod && npm run build:dev"
-  },
-  "type": "module"
+  }
 }


### PR DESCRIPTION
This removes the need to include the full path to the UMD bundle, when using UMD / CommonJS style `require`.

e.g:

```javascript
// before
const { DiceRoller } = require('rpg-dice-roller/lib/umd/bundle.js');

// now
const { DiceRoller } = require('rpg-dice-roller');
```

Resolves #173 