### PR TITLE
Bugfix/159 very large numbers not handled correctly

### DIFF
--- a/src/ComparePoint.js
+++ b/src/ComparePoint.js
@@ -74,10 +74,10 @@ class ComparePoint {
    */
   set value(value) {
     if (!diceUtils.isNumeric(value)) {
-      throw new TypeError('value must be numeric');
+      throw new TypeError('value must be a finite number');
     }
 
-    this[valueSymbol] = parseInt(value, 10);
+    this[valueSymbol] = Number(value);
   }
 
   /**

--- a/src/dice/FudgeDice.js
+++ b/src/dice/FudgeDice.js
@@ -10,7 +10,7 @@ class FudgeDice extends StandardDice {
    * Create a FudgeDice
    *
    * @param {string} notation The dice notation (e.g. '4dF')
-   * @param {number} [nonBlanks=2] The number of non-blanks the Fudge die should have
+   * @param {number} [nonBlanks=2] The number of non-blanks the Fudge die should have (1 or 2)
    * @param {number} [qty=1] The number of dice to roll (e.g. 4)
    * @param {Map<string, Modifier>|Modifier[]|{}|null} [modifiers=null]
    *

--- a/src/dice/StandardDice.js
+++ b/src/dice/StandardDice.js
@@ -35,10 +35,18 @@ class StandardDice {
   constructor(notation, sides, qty = 1, modifiers = null, min = 1, max = null) {
     if (!notation) {
       throw new RequiredArgumentError('notation');
-    } else if (!sides) {
+    }
+    if (!sides) {
       throw new RequiredArgumentError('sides');
-    } else if (!diceUtils.isNumeric(qty) || (qty < 1)) {
+    }
+    if (!diceUtils.isNumeric(qty) || (qty < 1)) {
       throw new TypeError('qty must be a positive integer');
+    }
+    if (!diceUtils.isNumeric(min)) {
+      throw new TypeError('min must a finite number');
+    }
+    if (max && !diceUtils.isNumeric(max)) {
+      throw new TypeError('max must be a finite number');
     }
 
     this[notationSymbol] = notation;
@@ -49,8 +57,9 @@ class StandardDice {
       this.modifiers = modifiers;
     }
 
-    this[minSymbol] = diceUtils.isNumeric(min) ? parseInt(min, 10) : 1;
-    this[maxSymbol] = diceUtils.isNumeric(max) ? parseInt(max, 10) : sides;
+    this[minSymbol] = parseInt(min, 10);
+
+    this[maxSymbol] = max ? parseInt(max, 10) : sides;
   }
 
   /**
@@ -145,6 +154,7 @@ class StandardDice {
   get name() {
     return 'standard';
   }
+
   /* eslint-enable class-methods-use-this */
 
   /**

--- a/src/dice/StandardDice.js
+++ b/src/dice/StandardDice.js
@@ -36,17 +36,35 @@ class StandardDice {
     if (!notation) {
       throw new RequiredArgumentError('notation');
     }
-    if (!sides) {
+
+    if (!sides && (sides !== 0)) {
       throw new RequiredArgumentError('sides');
+    } else if (sides === Infinity) {
+      throw new RangeError('numerical sides must be finite number');
+    } else if (diceUtils.isNumeric(sides)) {
+      if ((sides < 1) || !diceUtils.isSafeNumber(sides)) {
+        throw new RangeError('numerical sides must be a positive finite number');
+      }
+    } else if (typeof sides !== 'string') {
+      throw new TypeError('non-numerical sides must be a string');
     }
-    if (!diceUtils.isNumeric(qty) || (qty < 1)) {
-      throw new TypeError('qty must be a positive integer');
+
+    if (!diceUtils.isNumeric(qty)) {
+      throw new TypeError('qty must be a positive finite integer');
+    } else if ((qty < 1) || !diceUtils.isSafeNumber(qty)) {
+      throw new RangeError('qty must be a positive finite integer');
     }
+
     if (!diceUtils.isNumeric(min)) {
       throw new TypeError('min must a finite number');
+    } else if (!diceUtils.isSafeNumber(min)) {
+      throw new RangeError('min must a finite number');
     }
+
     if (max && !diceUtils.isNumeric(max)) {
-      throw new TypeError('max must be a finite number');
+      throw new TypeError('max must a finite number');
+    } else if (max && !diceUtils.isSafeNumber(max)) {
+      throw new RangeError('max must a finite number');
     }
 
     this[notationSymbol] = notation;

--- a/src/modifiers/ExplodeModifier.js
+++ b/src/modifiers/ExplodeModifier.js
@@ -106,7 +106,7 @@ class ExplodeModifier extends ComparisonModifier {
         /* eslint-disable  no-param-reassign */
         if (this.compound && (subRolls.length > 1)) {
           // update the roll value and modifiers
-          roll.value = diceUtils.sumArray(subRolls);
+          roll.value = diceUtils.sumArray(subRolls.map((result) => result.value));
           roll.modifiers = [
             'explode',
             'compound',

--- a/src/modifiers/KeepModifier.js
+++ b/src/modifiers/KeepModifier.js
@@ -76,14 +76,17 @@ class KeepModifier extends Modifier {
    *
    * @param {number} value
    *
-   * @throws {TypeError} qty must be a positive integer
+   * @throws {TypeError} qty must be a positive finite integer
    */
   set qty(value) {
+    if (value === Infinity) {
+      throw new RangeError('qty must be a finite number');
+    }
     if (!diceUtils.isNumeric(value) || (value < 1)) {
-      throw new TypeError('qty must be a positive integer');
+      throw new TypeError('qty must be a positive finite integer');
     }
 
-    this[qtySymbol] = parseInt(value, 10);
+    this[qtySymbol] = Math.floor(value);
   }
 
   /**

--- a/src/results/RollResult.js
+++ b/src/results/RollResult.js
@@ -21,7 +21,7 @@ class RollResult {
    */
   constructor(value, modifiers = [], useInTotal = true) {
     if (diceUtils.isNumeric(value)) {
-      this[initialValueSymbol] = parseInt(value, 10);
+      this[initialValueSymbol] = Number(value);
 
       this.modifiers = modifiers || [];
       this.useInTotal = useInTotal;
@@ -32,11 +32,11 @@ class RollResult {
         throw new TypeError(`Result value is invalid: ${initialVal}`);
       }
 
-      this[initialValueSymbol] = parseInt(initialVal, 10);
+      this[initialValueSymbol] = Number(initialVal);
 
       if (
         diceUtils.isNumeric(value.value)
-        && (parseInt(value.value, 10) !== this[initialValueSymbol])
+        && (Number(value.value) !== this[initialValueSymbol])
       ) {
         this.value = value.value;
       }
@@ -50,6 +50,8 @@ class RollResult {
 
       this.modifiers = value.modifiers || modifiers || [];
       this.useInTotal = (typeof value.useInTotal === 'boolean') ? value.useInTotal : (useInTotal || false);
+    } else if (value === Infinity) {
+      throw new RangeError('Result value must be a finite number');
     } else {
       throw new TypeError(`Result value is invalid: ${value}`);
     }
@@ -75,6 +77,9 @@ class RollResult {
    */
   set calculationValue(value) {
     const isNumeric = diceUtils.isNumeric(value);
+    if (value === Infinity) {
+      throw new RangeError('Result calculation value must be a finite number');
+    }
     if (value && !isNumeric) {
       throw new TypeError(`Result calculation value is invalid: ${value}`);
     }
@@ -214,11 +219,14 @@ class RollResult {
    * @throws {TypeError} value is invalid
    */
   set value(value) {
+    if (value === Infinity) {
+      throw new RangeError('Result value must be a finite number');
+    }
     if (!diceUtils.isNumeric(value)) {
       throw new TypeError(`Result value is invalid: ${value}`);
     }
 
-    this[valueSymbol] = parseInt(value, 10);
+    this[valueSymbol] = Number(value);
   }
 
   /**

--- a/src/utilities/utils.js
+++ b/src/utilities/utils.js
@@ -15,14 +15,18 @@
  */
 const diceUtils = Object.freeze({
   /**
-   * Checks if the given value is a valid number
+   * Checks if the given value is a valid finite number
    *
    * @param {*} val
    *
    * @returns {boolean}
    */
   isNumeric(val) {
-    return !Array.isArray(val) && !Number.isNaN(val) && Number.isFinite(parseInt(val, 10));
+    if ((typeof val !== 'number') && (typeof val !== 'string')) {
+      return false;
+    }
+
+    return !Number.isNaN(val) && Number.isFinite(Number(val));
   },
   /**
    * Checks if the string is valid base64 encoded
@@ -74,18 +78,21 @@ const diceUtils = Object.freeze({
   },
   /**
    * Checks if `a` is comparative to `b` with the given operator.
-   * Returns true or false.
    *
-   * @param {number} a
-   * @param {number} b
+   * @param {number|string} a The number to compare with `b`
+   * @param {number|string} b The number to compare with `a`
    * @param {string} operator A valid comparative operator (=, <, >, <=, >=, !=)
    *
    * @returns {boolean}
    */
   compareNumbers(a, b, operator) {
-    const aNum = parseFloat(a);
-    const bNum = parseFloat(b);
+    const aNum = Number(a);
+    const bNum = Number(b);
     let result;
+
+    if (Number.isNaN(aNum) || Number.isNaN(bNum)) {
+      return false;
+    }
 
     switch (operator) {
       case '=':

--- a/src/utilities/utils.js
+++ b/src/utilities/utils.js
@@ -5,13 +5,14 @@
  *
  * @type {Readonly<{
  *  compareNumbers(a: number, b: number, operator: string): boolean,
- *  toFixed(num: number, decPlaces: number=): number,
  *  generateNumber(min: number, max: number): number,
+ *  isBase64(val: string): boolean,
  *  isNumeric(val: *): boolean,
  *  isJson(val: string): boolean,
+ *  isSafeNumber(val: *): boolean,
  *  readonly sumArray(numbers: number[]): number,
- *  isBase64(val: string): boolean}>
- * }
+ *  toFixed(num: number, decPlaces: number=): number
+ * }>}
  */
 const diceUtils = Object.freeze({
   /**
@@ -57,6 +58,24 @@ const diceUtils = Object.freeze({
     } catch (e) {
       return false;
     }
+  },
+  /**
+   * Checks if the given value is a "safe" number.
+   * This means that it falls within the `Number.MAX_SAFE_INTEGER` and `Number.MIN_SAFE_INTEGER`
+   * values (Inclusive).
+   *
+   * @param {*} val
+   *
+   * @returns {boolean}
+   */
+  isSafeNumber(val) {
+    if (!this.isNumeric(val)) {
+      return false;
+    }
+
+    const castVal = Number(val);
+
+    return (castVal <= Number.MAX_SAFE_INTEGER) && (castVal >= Number.MIN_SAFE_INTEGER);
   },
   /**
    * @returns {function(number[]): number}

--- a/tests/ComparePoint.test.js
+++ b/tests/ComparePoint.test.js
@@ -289,19 +289,51 @@ describe('ComparePoint', () => {
       expect(cp.isMatch('4')).toBe(false);
     });
 
-    test('falsey values do not match against zero', () => {
-      const cp = new ComparePoint('=', 0);
-
-      expect(cp.isMatch(0)).toBe(true);
-      expect(cp.isMatch(null)).toBe(false);
-      expect(cp.isMatch(undefined)).toBe(false);
-    });
-
-    test('truthy values do not match against 1', () => {
+    test('truthy values match against 1', () => {
       const cp = new ComparePoint('=', 1);
 
       expect(cp.isMatch(1)).toBe(true);
-      expect(cp.isMatch(true)).toBe(false);
+      expect(cp.isMatch(true)).toBe(true);
+    });
+
+    test('falsey values match against zero', () => {
+      const cp = new ComparePoint('=', 0);
+
+      expect(cp.isMatch(0)).toBe(true);
+      expect(cp.isMatch(null)).toBe(true);
+    });
+
+    test('undefined does not match against zero', () => {
+      const cp = new ComparePoint('=', 0);
+      expect(cp.isMatch(undefined)).toBe(false);
+    });
+
+    describe('Very large numbers', () => {
+      test('can compare very large numbers as numbers', () => {
+        const cp = new ComparePoint('=', 99 ** 99);
+
+        expect(cp.isMatch(99 ** 99)).toBe(true);
+        expect(cp.isMatch(4)).toBe(false);
+      });
+
+      test('can compare very large numbers as strings', () => {
+        const cp = new ComparePoint('=', (99 ** 99).toString());
+        expect(cp.isMatch((99 ** 99).toString())).toBe(true);
+        expect(cp.isMatch('4')).toBe(false);
+      });
+
+      test('comparing very large numbers does not incorrectly round them', () => {
+        // check if 99^99 is greater than 4, because if incorrectly
+        // rounding (e.g parseInt) it converts it to `3`
+        const cp = new ComparePoint('>', 4);
+        expect(cp.isMatch(99 ** 99)).toBe(true);
+      });
+
+      test('comparing infinity throws error', () => {
+        expect(() => {
+          new ComparePoint('=', Infinity);
+        }).toThrow(TypeError);
+      });
     });
   });
 });

--- a/tests/dice/FudgeDice.test.js
+++ b/tests/dice/FudgeDice.test.js
@@ -144,15 +144,15 @@ describe('FudgeDice', () => {
 
       expect(() => {
         die = new FudgeDice('4dF', null, 0);
-      }).toThrow(TypeError);
+      }).toThrow(RangeError);
 
       expect(() => {
         die = new FudgeDice('4dF', null, -42);
-      }).toThrow(TypeError);
+      }).toThrow(RangeError);
 
       expect(() => {
         die = new FudgeDice('4dF', null, -1);
-      }).toThrow(TypeError);
+      }).toThrow(RangeError);
     });
   });
 

--- a/tests/dice/PercentileDice.test.js
+++ b/tests/dice/PercentileDice.test.js
@@ -82,15 +82,15 @@ describe('PercentileDice', () => {
 
       expect(() => {
         die = new PercentileDice('4d%', 0);
-      }).toThrow(TypeError);
+      }).toThrow(RangeError);
 
       expect(() => {
         die = new PercentileDice('4d%', -42);
-      }).toThrow(TypeError);
+      }).toThrow(RangeError);
 
       expect(() => {
         die = new PercentileDice('4d%', -1);
-      }).toThrow(TypeError);
+      }).toThrow(RangeError);
     });
   });
 

--- a/tests/dice/StandardDice.test.js
+++ b/tests/dice/StandardDice.test.js
@@ -74,6 +74,79 @@ describe('StandardDice', () => {
     });
   });
 
+  describe('Sides', () => {
+    test('must be numeric or string', () => {
+      let die = new StandardDice('d1', 1);
+      expect(die.sides).toBe(1);
+
+      die = new StandardDice('d9', 'foo');
+      expect(die.sides).toBe('foo');
+
+      expect(() => {
+        new StandardDice('d6', {});
+      }).toThrow(TypeError);
+
+      expect(() => {
+        new StandardDice('d6', []);
+      }).toThrow(TypeError);
+    });
+
+    describe('If numeric...', () => {
+      test('must be positive non-zero', () => {
+        let die = new StandardDice('d1', 1);
+        expect(die.sides).toBe(1);
+
+        die = new StandardDice('d9', 9);
+        expect(die.sides).toBe(9);
+
+        die = new StandardDice('d689', 689);
+        expect(die.sides).toBe(689);
+
+        expect(() => {
+          new StandardDice('d6', 0);
+        }).toThrow(RangeError);
+
+        expect(() => {
+          new StandardDice('d6', -42);
+        }).toThrow(RangeError);
+
+        expect(() => {
+          new StandardDice('d6', -1);
+        }).toThrow(RangeError);
+      });
+
+      test('can be float', () => {
+        let die = new StandardDice('d1', 5.67);
+        expect(die.sides).toBeCloseTo(5.67);
+
+        die = new StandardDice('d9', 589.138);
+        expect(die.sides).toBeCloseTo(589.138);
+
+        die = new StandardDice('d9', 13.5);
+        expect(die.sides).toBeCloseTo(13.5);
+      });
+
+      test('must be finite', () => {
+        expect(() => {
+          new StandardDice('4d6', Infinity);
+        }).toThrow(RangeError);
+      });
+
+      describe('"Safe" number', () => {
+        test('can be equal to `Number.MAX_SAFE_INTEGER`', () => {
+          const die = new StandardDice('4d6', Number.MAX_SAFE_INTEGER);
+          expect(die.sides).toBe(Number.MAX_SAFE_INTEGER);
+        });
+
+        test('cannot be greater than `Number.MAX_SAFE_INTEGER`', () => {
+          expect(() => {
+            new StandardDice('4d6', Number.MAX_SAFE_INTEGER + 1);
+          }).toThrow(RangeError);
+        });
+      });
+    });
+  });
+
   describe('Quantity', () => {
     test('must be numeric', () => {
       let die = new StandardDice('4d6', 6, 8);
@@ -109,15 +182,15 @@ describe('StandardDice', () => {
 
       expect(() => {
         die = new StandardDice('4d6', 6, 0);
-      }).toThrow(TypeError);
+      }).toThrow(RangeError);
 
       expect(() => {
         die = new StandardDice('4d6', 6, -42);
-      }).toThrow(TypeError);
+      }).toThrow(RangeError);
 
       expect(() => {
         die = new StandardDice('4d6', 6, -1);
-      }).toThrow(TypeError);
+      }).toThrow(RangeError);
     });
 
     test('float values are floored to integer', () => {
@@ -135,6 +208,19 @@ describe('StandardDice', () => {
       expect(() => {
         new StandardDice('4d6', 6, Infinity);
       }).toThrow(TypeError);
+    });
+
+    describe('"Safe" number', () => {
+      test('can be equal to `Number.MAX_SAFE_INTEGER`', () => {
+        const die = new StandardDice('4d6', 6, Number.MAX_SAFE_INTEGER);
+        expect(die.qty).toBe(Number.MAX_SAFE_INTEGER);
+      });
+
+      test('cannot be greater than `Number.MAX_SAFE_INTEGER`', () => {
+        expect(() => {
+          new StandardDice('4d6', 6, Number.MAX_SAFE_INTEGER + 1);
+        }).toThrow(RangeError);
+      });
     });
   });
 
@@ -180,6 +266,30 @@ describe('StandardDice', () => {
         new StandardDice('4d6', 6, 4, null, Infinity);
       }).toThrow(TypeError);
     });
+
+    describe('"Safe" number', () => {
+      test('can be equal to `Number.MAX_SAFE_INTEGER`', () => {
+        const die = new StandardDice('4d6', 6, 4, null, Number.MAX_SAFE_INTEGER);
+        expect(die.min).toBe(Number.MAX_SAFE_INTEGER);
+      });
+
+      test('cannot be greater than `Number.MAX_SAFE_INTEGER`', () => {
+        expect(() => {
+          new StandardDice('4d6', 6, 4, null, Number.MAX_SAFE_INTEGER + 1);
+        }).toThrow(RangeError);
+      });
+
+      test('can be equal to `Number.MIN_SAFE_INTEGER`', () => {
+        const die = new StandardDice('4d6', 6, 4, null, Number.MIN_SAFE_INTEGER);
+        expect(die.min).toBe(Number.MIN_SAFE_INTEGER);
+      });
+
+      test('cannot be less than `Number.MIN_SAFE_INTEGER`', () => {
+        expect(() => {
+          new StandardDice('4d6', 6, 4, null, Number.MIN_SAFE_INTEGER - 1);
+        }).toThrow(RangeError);
+      });
+    });
   });
 
   describe('Max', () => {
@@ -223,6 +333,30 @@ describe('StandardDice', () => {
       expect(() => {
         new StandardDice('4d6', 6, 4, null, 1, Infinity);
       }).toThrow(TypeError);
+    });
+
+    describe('"Safe" number', () => {
+      test('can be equal to `Number.MAX_SAFE_INTEGER`', () => {
+        const die = new StandardDice('4d6', 6, 4, null, 1, Number.MAX_SAFE_INTEGER);
+        expect(die.max).toBe(Number.MAX_SAFE_INTEGER);
+      });
+
+      test('cannot be greater than `Number.MAX_SAFE_INTEGER`', () => {
+        expect(() => {
+          new StandardDice('4d6', 6, 4, null, 1, Number.MAX_SAFE_INTEGER + 1);
+        }).toThrow(RangeError);
+      });
+
+      test('can be equal to `Number.MIN_SAFE_INTEGER`', () => {
+        const die = new StandardDice('4d6', 6, 4, null, 1, Number.MIN_SAFE_INTEGER);
+        expect(die.max).toBe(Number.MIN_SAFE_INTEGER);
+      });
+
+      test('cannot be less than `Number.MIN_SAFE_INTEGER`', () => {
+        expect(() => {
+          new StandardDice('4d6', 6, 4, null, 1, Number.MIN_SAFE_INTEGER - 1);
+        }).toThrow(RangeError);
+      });
     });
   });
 

--- a/tests/dice/StandardDice.test.js
+++ b/tests/dice/StandardDice.test.js
@@ -67,27 +67,15 @@ describe('StandardDice', () => {
       expect(die.min).toBe(3);
     });
 
-    test('Non-numeric `min` is treated as `1`', () => {
-      const die = new StandardDice('4d6', 6, 4, null, 'foo');
-
-      expect(die.min).toBe(1);
-    });
-
     test('can set `max` in constructor', () => {
-      const die = new StandardDice('4d6', 6, 4, null, null, 8);
+      const die = new StandardDice('4d6', 6, 4, null, 1, 8);
 
       expect(die.max).toBe(8);
-    });
-
-    test('Non-numeric `max` is treated as value of sides', () => {
-      const die = new StandardDice('4d6', 6, 4, null, null, 'foo');
-
-      expect(die.max).toBe(6);
     });
   });
 
   describe('Quantity', () => {
-    test('qty must be numeric', () => {
+    test('must be numeric', () => {
       let die = new StandardDice('4d6', 6, 8);
       expect(die.qty).toBe(8);
 
@@ -112,7 +100,7 @@ describe('StandardDice', () => {
       }).toThrow(TypeError);
     });
 
-    test('qty must be positive non-zero', () => {
+    test('must be positive non-zero', () => {
       let die = new StandardDice('4d6', 6, 1);
       expect(die.qty).toBe(1);
 
@@ -129,6 +117,111 @@ describe('StandardDice', () => {
 
       expect(() => {
         die = new StandardDice('4d6', 6, -1);
+      }).toThrow(TypeError);
+    });
+
+    test('float values are floored to integer', () => {
+      let die = new StandardDice('4d6', 6, 8.1);
+      expect(die.qty).toBe(8);
+
+      die = new StandardDice('4d6', 6, 5.9);
+      expect(die.qty).toBe(5);
+
+      die = new StandardDice('4d6', 6, 67.5);
+      expect(die.qty).toBe(67);
+    });
+
+    test('must be finite', () => {
+      expect(() => {
+        new StandardDice('4d6', 6, Infinity);
+      }).toThrow(TypeError);
+    });
+  });
+
+  describe('Min', () => {
+    test('must be numeric', () => {
+      const die = new StandardDice('4d6', 6, 8, null, 3);
+      expect(die.min).toBe(3);
+
+      expect(() => {
+        new StandardDice('4d6', 6, 8, null, 'foo');
+      }).toThrow(TypeError);
+
+      expect(() => {
+        new StandardDice('4d6', 6, 8, null, false);
+      }).toThrow(TypeError);
+
+      expect(() => {
+        new StandardDice('4d6', 6, 8, null, true);
+      }).toThrow(TypeError);
+
+      expect(() => {
+        new StandardDice('4d6', 6, 8, null, []);
+      }).toThrow(TypeError);
+
+      expect(() => {
+        new StandardDice('4d6', 6, 8, null, { min: 4 });
+      }).toThrow(TypeError);
+    });
+
+    test('float values are floored to integer', () => {
+      let die = new StandardDice('4d6', 6, 4, null, 4.23);
+      expect(die.min).toBe(4);
+
+      die = new StandardDice('4d6', 6, 4, null, -14.78);
+      expect(die.min).toBe(-14);
+
+      die = new StandardDice('4d6', 6, 4, null, 145.5);
+      expect(die.min).toBe(145);
+    });
+
+    test('must be finite', () => {
+      expect(() => {
+        new StandardDice('4d6', 6, 4, null, Infinity);
+      }).toThrow(TypeError);
+    });
+  });
+
+  describe('Max', () => {
+    test('falsey is treated as value of sides', () => {
+      let die = new StandardDice('4d6', 6, 4, null, 1, false);
+      expect(die.max).toBe(6);
+
+      die = new StandardDice('4d6', 6, 4, null, 1, null);
+      expect(die.max).toBe(6);
+
+      die = new StandardDice('4d6', 6, 4, null, 1, undefined);
+      expect(die.max).toBe(6);
+    });
+
+    test('non-numeric throws an error', () => {
+      expect(() => {
+        new StandardDice('4d6', 6, 4, null, 1, 'foo');
+      }).toThrow(TypeError);
+
+      expect(() => {
+        new StandardDice('4d6', 6, 4, null, 1, []);
+      }).toThrow(TypeError);
+
+      expect(() => {
+        new StandardDice('4d6', 6, 4, null, 1, {});
+      }).toThrow(TypeError);
+    });
+
+    test('float values are floored to integer', () => {
+      let die = new StandardDice('4d6', 6, 4, null, 1, 65.143);
+      expect(die.max).toBe(65);
+
+      die = new StandardDice('4d6', 6, 4, null, 1, -578.891);
+      expect(die.max).toBe(-578);
+
+      die = new StandardDice('4d6', 6, 4, null, 1, 4.5);
+      expect(die.max).toBe(4);
+    });
+
+    test('must be finite', () => {
+      expect(() => {
+        new StandardDice('4d6', 6, 4, null, 1, Infinity);
       }).toThrow(TypeError);
     });
   });

--- a/tests/modifiers/ExplodeModifier.test.js
+++ b/tests/modifiers/ExplodeModifier.test.js
@@ -166,7 +166,6 @@ describe('ExplodeModifier', () => {
       mod = new ExplodeModifier('!');
 
       jest.spyOn(StandardDice.prototype, 'rollOnce')
-        // .mockResolvedValue(new RollResult(1));
         .mockImplementationOnce(() => new RollResult(10))
         .mockImplementationOnce(() => new RollResult(2))
         .mockImplementationOnce(() => new RollResult(5))
@@ -360,44 +359,36 @@ describe('ExplodeModifier', () => {
 
       // assert that all the rolls exist
       expect(rolls.length).toEqual(6);
-      expect(rolls).toEqual([
-        expect.objectContaining({
-          initialValue: 8,
-          modifierFlags: '!!',
-          modifiers: new Set(['explode', 'compound']),
-          value: 20,
-        }),
-        expect.objectContaining({
-          initialValue: 4,
-          modifierFlags: '',
-          modifiers: new Set(),
-          value: 4,
-        }),
-        expect.objectContaining({
-          initialValue: 2,
-          modifierFlags: '',
-          modifiers: new Set(),
-          value: 2,
-        }),
-        expect.objectContaining({
-          initialValue: 1,
-          modifierFlags: '',
-          modifiers: new Set(),
-          value: 1,
-        }),
-        expect.objectContaining({
-          initialValue: 6,
-          modifierFlags: '!!',
-          modifiers: new Set(['explode', 'compound']),
-          value: 11,
-        }),
-        expect.objectContaining({
-          initialValue: 10,
-          modifierFlags: '!!',
-          modifiers: new Set(['explode', 'compound']),
-          value: 21,
-        }),
-      ]);
+
+      expect(rolls[0].initialValue).toBe(8);
+      expect(rolls[0].modifierFlags).toEqual('!!');
+      expect(rolls[0].modifiers).toEqual(new Set(['explode', 'compound']));
+      expect(rolls[0].value).toBe(20);
+
+      expect(rolls[1].initialValue).toBe(4);
+      expect(rolls[1].modifierFlags).toEqual('');
+      expect(rolls[1].modifiers).toEqual(new Set());
+      expect(rolls[1].value).toBe(4);
+
+      expect(rolls[2].initialValue).toBe(2);
+      expect(rolls[2].modifierFlags).toEqual('');
+      expect(rolls[2].modifiers).toEqual(new Set());
+      expect(rolls[2].value).toBe(2);
+
+      expect(rolls[3].initialValue).toBe(1);
+      expect(rolls[3].modifierFlags).toEqual('');
+      expect(rolls[3].modifiers).toEqual(new Set());
+      expect(rolls[3].value).toBe(1);
+
+      expect(rolls[4].initialValue).toBe(6);
+      expect(rolls[4].modifierFlags).toEqual('!!');
+      expect(rolls[4].modifiers).toEqual(new Set(['explode', 'compound']));
+      expect(rolls[4].value).toBe(11);
+
+      expect(rolls[5].initialValue).toBe(10);
+      expect(rolls[5].modifierFlags).toEqual('!!');
+      expect(rolls[5].modifiers).toEqual(new Set(['explode', 'compound']));
+      expect(rolls[5].value).toBe(21);
     });
 
     test('can penetrate with compare point `<=4`', () => {
@@ -478,44 +469,36 @@ describe('ExplodeModifier', () => {
 
       // assert that all the rolls exist
       expect(rolls.length).toEqual(6);
-      expect(rolls).toEqual([
-        expect.objectContaining({
-          initialValue: 8,
-          modifierFlags: '!!p',
-          modifiers: new Set(['explode', 'compound', 'penetrate']),
-          value: 18,
-        }),
-        expect.objectContaining({
-          initialValue: 4,
-          modifierFlags: '',
-          modifiers: new Set(),
-          value: 4,
-        }),
-        expect.objectContaining({
-          initialValue: 2,
-          modifierFlags: '',
-          modifiers: new Set(),
-          value: 2,
-        }),
-        expect.objectContaining({
-          initialValue: 1,
-          modifierFlags: '',
-          modifiers: new Set(),
-          value: 1,
-        }),
-        expect.objectContaining({
-          initialValue: 6,
-          modifierFlags: '',
-          modifiers: new Set(),
-          value: 6,
-        }),
-        expect.objectContaining({
-          initialValue: 10,
-          modifierFlags: '!!p',
-          modifiers: new Set(['explode', 'compound', 'penetrate']),
-          value: 14,
-        }),
-      ]);
+
+      expect(rolls[0].initialValue).toBe(8);
+      expect(rolls[0].modifierFlags).toEqual('!!p');
+      expect(rolls[0].modifiers).toEqual(new Set(['explode', 'compound', 'penetrate']));
+      expect(rolls[0].value).toBe(18);
+
+      expect(rolls[1].initialValue).toBe(4);
+      expect(rolls[1].modifierFlags).toEqual('');
+      expect(rolls[1].modifiers).toEqual(new Set());
+      expect(rolls[1].value).toBe(4);
+
+      expect(rolls[2].initialValue).toBe(2);
+      expect(rolls[2].modifierFlags).toEqual('');
+      expect(rolls[2].modifiers).toEqual(new Set());
+      expect(rolls[2].value).toBe(2);
+
+      expect(rolls[3].initialValue).toBe(1);
+      expect(rolls[3].modifierFlags).toEqual('');
+      expect(rolls[3].modifiers).toEqual(new Set());
+      expect(rolls[3].value).toBe(1);
+
+      expect(rolls[4].initialValue).toBe(6);
+      expect(rolls[4].modifierFlags).toEqual('');
+      expect(rolls[4].modifiers).toEqual(new Set());
+      expect(rolls[4].value).toBe(6);
+
+      expect(rolls[5].initialValue).toBe(10);
+      expect(rolls[5].modifierFlags).toEqual('!!p');
+      expect(rolls[5].modifiers).toEqual(new Set(['explode', 'compound', 'penetrate']));
+      expect(rolls[5].value).toBe(14);
     });
 
     test('exploding with d1 throws an error', () => {

--- a/tests/modifiers/KeepModifier.test.js
+++ b/tests/modifiers/KeepModifier.test.js
@@ -154,6 +154,28 @@ describe('KeepModifier', () => {
         mod.qty = -1;
       }).toThrow(TypeError);
     });
+
+    test('float gets floored to integer', () => {
+      let mod = new KeepModifier('kh', 'h', 5.145);
+      expect(mod.qty).toBeCloseTo(5);
+
+      mod = new KeepModifier('kh', 'h', 12.7);
+      expect(mod.qty).toBeCloseTo(12);
+
+      mod = new KeepModifier('kh', 'h', 50.5);
+      expect(mod.qty).toBeCloseTo(50);
+    });
+
+    test('must be finite', () => {
+      expect(() => {
+        new KeepModifier('kh', 'h', Infinity);
+      }).toThrow(RangeError);
+    });
+
+    test('can be very large number', () => {
+      const mod = new KeepModifier('kh', 'h', 99 ** 99);
+      expect(mod.qty).toBe(99 ** 99);
+    });
   });
 
   describe('Output', () => {

--- a/tests/results/RollResult.test.js
+++ b/tests/results/RollResult.test.js
@@ -92,6 +92,7 @@ describe('RollResult', () => {
       expect((new RollResult(-45)).initialValue).toBe(-45);
       expect((new RollResult(0)).initialValue).toBe(0);
       expect((new RollResult(360)).initialValue).toBe(360);
+      expect((new RollResult(43.256)).initialValue).toBeCloseTo(43.256);
 
       expect(() => {
         new RollResult('foo');
@@ -112,6 +113,16 @@ describe('RollResult', () => {
       expect(() => {
         new RollResult({ value: 'foo' });
       }).toThrow(TypeError);
+    });
+
+    test('must be finite', () => {
+      expect(() => {
+        new RollResult(Infinity);
+      }).toThrow(RangeError);
+    });
+
+    test('can be very large number', () => {
+      expect((new RollResult(99 ** 99)).initialValue).toBe(99 ** 99);
     });
   });
 
@@ -155,6 +166,9 @@ describe('RollResult', () => {
 
       result.value = 245;
       expect(result.value).toBe(245);
+
+      result.value = 56.365;
+      expect(result.value).toBeCloseTo(56.365);
     });
 
     test('changing value does not affect initialValue', () => {
@@ -221,6 +235,19 @@ describe('RollResult', () => {
         result.value = null;
       }).toThrow(TypeError);
     });
+
+    test('must be finite', () => {
+      expect(() => {
+        (new RollResult(45)).value = Infinity;
+      }).toThrow(RangeError);
+    });
+
+    test('can be very large number', () => {
+      const result = new RollResult(3);
+
+      result.value = 99 ** 99;
+      expect(result.value).toBe(99 ** 99);
+    });
   });
 
   describe('Calculation Value', () => {
@@ -256,6 +283,9 @@ describe('RollResult', () => {
 
       result.calculationValue = 360;
       expect(result.calculationValue).toBe(360);
+
+      result.calculationValue = 78.35;
+      expect(result.calculationValue).toBeCloseTo(78.35);
 
       expect(() => {
         result.calculationValue = 'foo';
@@ -309,6 +339,19 @@ describe('RollResult', () => {
       expect(result.initialValue).toBe(45);
       expect(result.value).toBe(45);
       expect(result.calculationValue).toBe(3);
+    });
+
+    test('must be finite', () => {
+      expect(() => {
+        (new RollResult(45)).calculationValue = Infinity;
+      }).toThrow(RangeError);
+    });
+
+    test('can be very large number', () => {
+      const result = new RollResult(3);
+
+      result.calculationValue = 99 ** 99;
+      expect(result.calculationValue).toBe(99 ** 99);
     });
   });
 

--- a/tests/utilities/utils.test.js
+++ b/tests/utilities/utils.test.js
@@ -126,6 +126,47 @@ describe('Utilities', () => {
     });
   });
 
+  describe('isSafeNumber', () => {
+    test('returns true for values within the "safe" range', () => {
+      expect(diceUtils.isSafeNumber(1)).toBe(true);
+      expect(diceUtils.isSafeNumber(567689584)).toBe(true);
+      expect(diceUtils.isSafeNumber(721984.6432876523)).toBe(true);
+      expect(diceUtils.isSafeNumber(Number.MIN_SAFE_INTEGER + 1)).toBe(true);
+      expect(diceUtils.isSafeNumber(Number.MAX_SAFE_INTEGER - 1)).toBe(true);
+    });
+
+    test('returns true for the min', () => {
+      expect(diceUtils.isSafeNumber(Number.MIN_SAFE_INTEGER)).toBe(true);
+    });
+
+    test('returns true for the max', () => {
+      expect(diceUtils.isSafeNumber(Number.MAX_SAFE_INTEGER)).toBe(true);
+    });
+
+    test('returns false for numbers under the min', () => {
+      expect(diceUtils.isSafeNumber(Number.MIN_SAFE_INTEGER - 1)).toBe(false);
+      expect(diceUtils.isSafeNumber(Number.MIN_SAFE_INTEGER - 500)).toBe(false);
+      expect(diceUtils.isSafeNumber(Number.MIN_SAFE_INTEGER - 1564367.4325671)).toBe(false);
+    });
+
+    test('returns false for numbers over the max', () => {
+      expect(diceUtils.isSafeNumber(Number.MAX_SAFE_INTEGER + 1)).toBe(false);
+      expect(diceUtils.isSafeNumber(Number.MAX_SAFE_INTEGER + 500)).toBe(false);
+      expect(diceUtils.isSafeNumber(Number.MAX_SAFE_INTEGER + 1564367.432567)).toBe(false);
+      expect(diceUtils.isSafeNumber(Infinity)).toBe(false);
+    });
+
+    test('returns false for non-numeric values', () => {
+      expect(diceUtils.isSafeNumber('foo')).toBe(false);
+      expect(diceUtils.isSafeNumber([])).toBe(false);
+      expect(diceUtils.isSafeNumber({})).toBe(false);
+      expect(diceUtils.isSafeNumber(true)).toBe(false);
+      expect(diceUtils.isSafeNumber(false)).toBe(false);
+      expect(diceUtils.isSafeNumber(null)).toBe(false);
+      expect(diceUtils.isSafeNumber(undefined)).toBe(false);
+    });
+  });
+
   describe('sumArray', () => {
     test('Sums the values of an array', () => {
       expect(diceUtils.sumArray([4, 6, 234, 14.05, -4])).toBeCloseTo(254.05);


### PR DESCRIPTION
This correctly handles very large numbers like `6.022e23` (For `6.022 × 10<sup>23</sup>`), without incorrectly parsing them to `6`.

However, it does also block numbers greater than [`Number.MAX_SAFE_INTEGER`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER) (9007199254740991) from being used for die sides or quantity, so you'll unlikely hit a scenario where this would be a potential issue anyway.

The resolves #159 and is relevant to #137 but doesn't solve it.