### PR TITLE
Restrict die max quantity to 999

### DIFF
--- a/src/dice/StandardDice.js
+++ b/src/dice/StandardDice.js
@@ -51,8 +51,8 @@ class StandardDice {
 
     if (!diceUtils.isNumeric(qty)) {
       throw new TypeError('qty must be a positive finite integer');
-    } else if ((qty < 1) || !diceUtils.isSafeNumber(qty)) {
-      throw new RangeError('qty must be a positive finite integer');
+    } else if ((qty < 1) || (qty > 999)) {
+      throw new RangeError('qty must be between 1 and 999');
     }
 
     if (!diceUtils.isNumeric(min)) {

--- a/tests/dice/StandardDice.test.js
+++ b/tests/dice/StandardDice.test.js
@@ -193,6 +193,30 @@ describe('StandardDice', () => {
       }).toThrow(RangeError);
     });
 
+    test('cannot be greater than 999', () => {
+      let die = new StandardDice('4d6', 6, 999);
+      expect(die.qty).toBe(999);
+
+      die = new StandardDice('324d6', 6, 998);
+      expect(die.qty).toBe(998);
+
+      expect(() => {
+        die = new StandardDice('4d6', 6, 1000);
+      }).toThrow(RangeError);
+
+      expect(() => {
+        die = new StandardDice('4d6', 6, 1001);
+      }).toThrow(RangeError);
+
+      expect(() => {
+        die = new StandardDice('4d6', 6, 50000);
+      }).toThrow(RangeError);
+
+      expect(() => {
+        die = new StandardDice('4d6', 6, 9999);
+      }).toThrow(RangeError);
+    });
+
     test('float values are floored to integer', () => {
       let die = new StandardDice('4d6', 6, 8.1);
       expect(die.qty).toBe(8);
@@ -208,19 +232,6 @@ describe('StandardDice', () => {
       expect(() => {
         new StandardDice('4d6', 6, Infinity);
       }).toThrow(TypeError);
-    });
-
-    describe('"Safe" number', () => {
-      test('can be equal to `Number.MAX_SAFE_INTEGER`', () => {
-        const die = new StandardDice('4d6', 6, Number.MAX_SAFE_INTEGER);
-        expect(die.qty).toBe(Number.MAX_SAFE_INTEGER);
-      });
-
-      test('cannot be greater than `Number.MAX_SAFE_INTEGER`', () => {
-        expect(() => {
-          new StandardDice('4d6', 6, Number.MAX_SAFE_INTEGER + 1);
-        }).toThrow(RangeError);
-      });
     });
   });
 

--- a/tests/parser/Parser.test.js
+++ b/tests/parser/Parser.test.js
@@ -623,16 +623,16 @@ describe('Parser', () => {
           }));
         });
 
-        test('keep highest for `23017d2kh1`', () => {
-          const parsed = Parser.parse('23017d2kh1');
+        test('keep highest for `897d2kh1`', () => {
+          const parsed = Parser.parse('897d2kh1');
 
           expect(parsed).toBeInstanceOf(Array);
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('23017d2');
+          expect(parsed[0].notation).toEqual('897d2');
           expect(parsed[0].sides).toEqual(2);
-          expect(parsed[0].qty).toEqual(23017);
+          expect(parsed[0].qty).toEqual(897);
 
           expect(parsed[0].modifiers.has('keep-h')).toBe(true);
 
@@ -1707,16 +1707,16 @@ describe('Parser', () => {
     });
 
     describe('Roll high', () => {
-      test('can roll with a stupidly high qty', () => {
-        const parsed = Parser.parse('9999999999d6');
+      test('can roll with a qty of 999', () => {
+        const parsed = Parser.parse('999d6');
 
         expect(parsed).toBeInstanceOf(Array);
         expect(parsed).toHaveLength(1);
         expect(parsed[0]).toBeInstanceOf(StandardDice);
         expect(parsed[0]).toEqual(expect.objectContaining({
-          notation: '9999999999d6',
+          notation: '999d6',
           sides: 6,
-          qty: 9999999999,
+          qty: 999,
         }));
       });
 
@@ -1733,16 +1733,16 @@ describe('Parser', () => {
         }));
       });
 
-      test('can roll with a stupidly high everything', () => {
-        const parsed = Parser.parse('9999999999d9999999999');
+      test('can roll with a qty of 999 and stupidly high sides', () => {
+        const parsed = Parser.parse('999d9999999999');
 
         expect(parsed).toBeInstanceOf(Array);
         expect(parsed).toHaveLength(1);
         expect(parsed[0]).toBeInstanceOf(StandardDice);
         expect(parsed[0]).toEqual(expect.objectContaining({
-          notation: '9999999999d9999999999',
+          notation: '999d9999999999',
           sides: 9999999999,
-          qty: 9999999999,
+          qty: 999,
         }));
       });
     });


### PR DESCRIPTION
Limits the maximum quantity per die to `999`.

e.g:
```
999d20
999d20 + 999d10
```

References #137 