### PR TITLE
Don't require notation on internal objects (e.g. Dice, Modifiers, etc.)

### DIFF
--- a/src/dice/FudgeDice.js
+++ b/src/dice/FudgeDice.js
@@ -9,16 +9,14 @@ class FudgeDice extends StandardDice {
   /**
    * Create a FudgeDice
    *
-   * @param {string} notation The dice notation (e.g. '4dF')
    * @param {number} [nonBlanks=2] The number of non-blanks the Fudge die should have (1 or 2)
    * @param {number} [qty=1] The number of dice to roll (e.g. 4)
    * @param {Map<string, Modifier>|Modifier[]|{}|null} [modifiers=null]
    *
    * @throws {RangeError} nonBlanks must be 1 or 2
-   * @throws {RequiredArgumentError} Notation is required
    * @throws {TypeError} modifiers must be valid
    */
-  constructor(notation, nonBlanks = 2, qty = 1, modifiers = null) {
+  constructor(nonBlanks = 2, qty = 1, modifiers = null) {
     let numNonBlanks = nonBlanks;
 
     if (!numNonBlanks && (numNonBlanks !== 0)) {
@@ -27,7 +25,7 @@ class FudgeDice extends StandardDice {
       throw new RangeError('nonBlanks must be 1 or 2');
     }
 
-    super(notation, numNonBlanks, qty, modifiers, -1, 1);
+    super(numNonBlanks, qty, modifiers, -1, 1);
   }
 
   /* eslint-disable class-methods-use-this */

--- a/src/dice/PercentileDice.js
+++ b/src/dice/PercentileDice.js
@@ -7,16 +7,14 @@ class PercentileDice extends StandardDice {
   /**
    * Create a PercentileDice
    *
-   * @param {string} notation The dice notation (e.g. '4d%')
    * @param {number} [qty=1] The number of dice to roll (e.g. 4)
    * @param {Map<string, Modifier>|Modifier[]|{}|null} [modifiers=null]
    * @param {boolean} [sidesAsNumber=false] whether to show the sides as a number or percent symbol
    *
-   * @throws {RequiredArgumentError} Notation is required
    * @throws {TypeError} qty must be a positive integer, and modifiers must be valid
    */
-  constructor(notation, qty = 1, modifiers = null, sidesAsNumber = false) {
-    super(notation, 100, qty, modifiers);
+  constructor(qty = 1, modifiers = null, sidesAsNumber = false) {
+    super(100, qty, modifiers);
 
     this.sidesAsNumber = !!sidesAsNumber;
   }

--- a/src/dice/StandardDice.js
+++ b/src/dice/StandardDice.js
@@ -9,7 +9,6 @@ import Modifier from '../modifiers/Modifier';
 import RequiredArgumentError from '../exceptions/RequiredArgumentError';
 
 const modifiersSymbol = Symbol('modifiers');
-const notationSymbol = Symbol('notation');
 const qtySymbol = Symbol('qty');
 const sidesSymbol = Symbol('sides');
 const minSymbol = Symbol('min-value');
@@ -22,21 +21,16 @@ class StandardDice {
   /**
    * Create a StandardDice
    *
-   * @param {string} notation The dice notation (e.g. '4d6')
    * @param {number} sides The number of sides the die has (.e.g 6)
    * @param {number} [qty=1] The number of dice to roll (e.g. 4)
    * @param {Map<string, Modifier>|Modifier[]|{}|null} [modifiers=null]
    * @param {number|null} [min=1] The minimum possible roll value
    * @param {number|null} [max=null] The maximum possible roll value. Defaults to number of sides
    *
-   * @throws {RequiredArgumentError} Notation and sides are required
+   * @throws {RequiredArgumentError} sides is required
    * @throws {TypeError} qty must be a positive integer, and modifiers must be valid
    */
-  constructor(notation, sides, qty = 1, modifiers = null, min = 1, max = null) {
-    if (!notation) {
-      throw new RequiredArgumentError('notation');
-    }
-
+  constructor(sides, qty = 1, modifiers = null, min = 1, max = null) {
     if (!sides && (sides !== 0)) {
       throw new RequiredArgumentError('sides');
     } else if (sides === Infinity) {
@@ -67,7 +61,6 @@ class StandardDice {
       throw new RangeError('max must a finite number');
     }
 
-    this[notationSymbol] = notation;
     this[qtySymbol] = parseInt(qty, 10);
     this[sidesSymbol] = sides;
 
@@ -181,7 +174,13 @@ class StandardDice {
    * @returns {string}
    */
   get notation() {
-    return this[notationSymbol];
+    let notation = `${this.qty}d${this.sides}`;
+
+    if (this.modifiers && this.modifiers.size) {
+      notation += [...this.modifiers.values()].reduce((acc, modifier) => acc + modifier.notation, '');
+    }
+
+    return notation;
   }
 
   /**

--- a/src/modifiers/ComparisonModifier.js
+++ b/src/modifiers/ComparisonModifier.js
@@ -10,14 +10,12 @@ class ComparisonModifier extends Modifier {
   /**
    * Create a ComparisonModifier
    *
-   * @param {string} notation The modifier notation
-   * @param {ComparePoint} comparePoint The comparison object
+   * @param {ComparePoint} [comparePoint] The comparison object
    *
-   * @throws {RequiredArgumentError} Notation is required
    * @throws {TypeError} comparePoint must be a ComparePoint object
    */
-  constructor(notation, comparePoint) {
-    super(notation);
+  constructor(comparePoint) {
+    super();
 
     if (comparePoint) {
       this.comparePoint = comparePoint;
@@ -27,7 +25,7 @@ class ComparisonModifier extends Modifier {
   /**
    * Returns the compare point for the object
    *
-   * @returns {ComparePoint}
+   * @returns {ComparePoint|undefined}
    */
   get comparePoint() {
     return this[comparePointSymbol];
@@ -58,6 +56,15 @@ class ComparisonModifier extends Modifier {
     return 'comparison';
   }
   /* eslint-enable class-methods-use-this */
+
+  /**
+   * Returns the modifier notation
+   *
+   * @returns {string}
+   */
+  get notation() {
+    return `${this.comparePoint || ''}`;
+  }
 
   /**
    * Checks whether value matches the compare point

--- a/src/modifiers/CriticalFailureModifier.js
+++ b/src/modifiers/CriticalFailureModifier.js
@@ -7,14 +7,12 @@ class CriticalFailureModifier extends ComparisonModifier {
   /**
    * Create a CriticalFailureModifier
    *
-   * @param {string} notation The modifier notation
-   * @param {ComparePoint} comparePoint The comparison object
+   * @param {ComparePoint} [comparePoint] The comparison object
    *
-   * @throws {RequiredArgumentError} Notation is required
    * @throws {TypeError} comparePoint must be a ComparePoint object
    */
-  constructor(notation, comparePoint) {
-    super(notation, comparePoint);
+  constructor(comparePoint) {
+    super(comparePoint);
 
     // set the modifier's sort order
     this.order = 9;
@@ -30,6 +28,15 @@ class CriticalFailureModifier extends ComparisonModifier {
     return 'critical-failure';
   }
   /* eslint-enable class-methods-use-this */
+
+  /**
+   * Returns the modifier notation
+   *
+   * @returns {string}
+   */
+  get notation() {
+    return `cf${super.notation}`;
+  }
 
   /**
    * Runs the modifier on the rolls

--- a/src/modifiers/CriticalSuccessModifier.js
+++ b/src/modifiers/CriticalSuccessModifier.js
@@ -7,14 +7,12 @@ class CriticalSuccessModifier extends ComparisonModifier {
   /**
    * Create a CriticalSuccessModifier
    *
-   * @param {string} notation The modifier notation
    * @param {ComparePoint} comparePoint The comparison object
    *
-   * @throws {RequiredArgumentError} Notation is required
    * @throws {TypeError} comparePoint must be a ComparePoint object
    */
-  constructor(notation, comparePoint) {
-    super(notation, comparePoint);
+  constructor(comparePoint) {
+    super(comparePoint);
 
     // set the modifier's sort order
     this.order = 8;
@@ -30,6 +28,15 @@ class CriticalSuccessModifier extends ComparisonModifier {
     return 'critical-success';
   }
   /* eslint-enable class-methods-use-this */
+
+  /**
+   * Returns the modifier notation
+   *
+   * @returns {string}
+   */
+  get notation() {
+    return `cs${super.notation}`;
+  }
 
   /**
    * Runs the modifier on the rolls

--- a/src/modifiers/DropModifier.js
+++ b/src/modifiers/DropModifier.js
@@ -7,16 +7,14 @@ class DropModifier extends KeepModifier {
   /**
    * Create a DropModifier
    *
-   * @param {string} notation The modifier notation
    * @param {string} end Either `h|l` to drop highest or lowest
    * @param {number} [qty=1] The amount to keep
    *
    * @throws {RangeError} End must be one of 'h' or 'l'
-   * @throws {RequiredArgumentError} Notation is required
    * @throws {TypeError} qty must be a positive integer
    */
-  constructor(notation, end, qty = 1) {
-    super(notation, end, qty);
+  constructor(end, qty = 1) {
+    super(end, qty);
 
     // set the modifier's sort order
     this.order = 6;
@@ -29,6 +27,15 @@ class DropModifier extends KeepModifier {
    */
   get name() {
     return `drop-${this.end}`;
+  }
+
+  /**
+   * Returns the modifier notation
+   *
+   * @returns {string}
+   */
+  get notation() {
+    return `d${this.end}${this.qty}`;
   }
 
   /**

--- a/src/modifiers/ExplodeModifier.js
+++ b/src/modifiers/ExplodeModifier.js
@@ -12,16 +12,14 @@ class ExplodeModifier extends ComparisonModifier {
   /**
    * Create an ExplodeModifier
    *
-   * @param {string} notation The modifier notation
    * @param {ComparePoint} [comparePoint=null] The comparison object
    * @param {boolean} [compound=false] Whether to compound or not
    * @param {boolean} [penetrate=false] Whether to penetrate or not
    *
-   * @throws {RequiredArgumentError} Notation is required
    * @throws {TypeError} comparePoint must be a ComparePoint object
    */
-  constructor(notation, comparePoint = null, compound = false, penetrate = false) {
-    super(notation, comparePoint);
+  constructor(comparePoint = null, compound = false, penetrate = false) {
+    super(comparePoint);
 
     this[compoundSymbol] = !!compound;
     this[penetrateSymbol] = !!penetrate;
@@ -49,6 +47,15 @@ class ExplodeModifier extends ComparisonModifier {
     return 'explode';
   }
   /* eslint-enable class-methods-use-this */
+
+  /**
+   * Returns the modifier notation
+   *
+   * @returns {string}
+   */
+  get notation() {
+    return `!${this.compound ? '!' : ''}${this.penetrate ? 'p' : ''}${super.notation}`;
+  }
 
   /**
    * Whether the modifier should penetrate the results or not

--- a/src/modifiers/KeepModifier.js
+++ b/src/modifiers/KeepModifier.js
@@ -11,16 +11,14 @@ class KeepModifier extends Modifier {
   /**
    * Create a KeepModifier
    *
-   * @param {string} notation The modifier notation
    * @param {string} end Either `h|l` to keep highest or lowest
    * @param {number} [qty=1] The amount to keep
    *
    * @throws {RangeError} End must be one of 'h' or 'l'
-   * @throws {RequiredArgumentError} Notation is required
    * @throws {TypeError} qty must be a positive integer
    */
-  constructor(notation, end, qty = 1) {
-    super(notation);
+  constructor(end, qty = 1) {
+    super();
 
     this.end = end;
     this.qty = qty;
@@ -60,6 +58,15 @@ class KeepModifier extends Modifier {
    */
   get name() {
     return `keep-${this.end}`;
+  }
+
+  /**
+   * Returns the modifier notation
+   *
+   * @returns {string}
+   */
+  get notation() {
+    return `k${this.end}${this.qty}`;
   }
 
   /**

--- a/src/modifiers/MaxModifier.js
+++ b/src/modifiers/MaxModifier.js
@@ -10,13 +10,12 @@ class MaxModifier extends Modifier {
   /**
    * Create a MaxModifier
    *
-   * @param {string} notation The modifier notation
    * @param {number} max The maximum value
    *
    * @throws {TypeError} max must be a number
    */
-  constructor(notation, max) {
-    super(notation);
+  constructor(max) {
+    super();
 
     this.max = max;
 
@@ -58,6 +57,15 @@ class MaxModifier extends Modifier {
     return 'max';
   }
   /* eslint-enable class-methods-use-this */
+
+  /**
+   * Returns the modifier notation
+   *
+   * @returns {string}
+   */
+  get notation() {
+    return `max${this.max}`;
+  }
 
   /**
    * Runs the modifier on the rolls

--- a/src/modifiers/MinModifier.js
+++ b/src/modifiers/MinModifier.js
@@ -10,13 +10,12 @@ class MinModifier extends Modifier {
   /**
    * Create a MinModifier
    *
-   * @param {string} notation The modifier notation
    * @param {number} min The minimum value
    *
    * @throws {TypeError} min must be a number
    */
-  constructor(notation, min) {
-    super(notation);
+  constructor(min) {
+    super();
 
     this.min = min;
 
@@ -58,6 +57,15 @@ class MinModifier extends Modifier {
     return 'min';
   }
   /* eslint-enable class-methods-use-this */
+
+  /**
+   * Returns the modifier notation
+   *
+   * @returns {string}
+   */
+  get notation() {
+    return `min${this.min}`;
+  }
 
   /**
    * Runs the modifier on the rolls

--- a/src/modifiers/Modifier.js
+++ b/src/modifiers/Modifier.js
@@ -1,5 +1,3 @@
-import RequiredArgumentError from '../exceptions/RequiredArgumentError';
-
 /**
  * The base modifier class
  */
@@ -7,18 +5,9 @@ class Modifier {
   /**
    * Create a Modifier
    *
-   * @param {string} notation The modifier notation
-   *
    * @throws {RequiredArgumentError} Notation is required
    */
-  constructor(notation) {
-    if (!notation) {
-      throw new RequiredArgumentError('notation');
-    }
-
-    // set the modifier's notation
-    this.notation = notation;
-
+  constructor() {
     // set the modifier's sort order
     this.order = 999;
   }
@@ -31,6 +20,17 @@ class Modifier {
    */
   get name() {
     return 'modifier';
+  }
+  /* eslint-enable class-methods-use-this */
+
+  /* eslint-disable class-methods-use-this */
+  /**
+   * Returns the modifier notation
+   *
+   * @returns {string}
+   */
+  get notation() {
+    return '';
   }
   /* eslint-enable class-methods-use-this */
 

--- a/src/modifiers/ReRollModifier.js
+++ b/src/modifiers/ReRollModifier.js
@@ -10,12 +10,11 @@ class ReRollModifier extends ComparisonModifier {
   /**
    * Create a ReRollModifier
    *
-   * @param {string} notation The modifier notation
    * @param {boolean} [once=false] Whether to only re-roll once or not
    * @param {ComparePoint} [comparePoint=null] The comparison object
    */
-  constructor(notation, once = false, comparePoint = null) {
-    super(notation, comparePoint);
+  constructor(once = false, comparePoint = null) {
+    super(comparePoint);
 
     this.once = !!once;
 
@@ -33,6 +32,15 @@ class ReRollModifier extends ComparisonModifier {
     return 're-roll';
   }
   /* eslint-enable class-methods-use-this */
+
+  /**
+   * Returns the modifier notation
+   *
+   * @returns {string}
+   */
+  get notation() {
+    return `r${this.once ? 'o' : ''}${super.notation}`;
+  }
 
   /**
    * Returns whether the modifier should only re-roll once or not

--- a/src/modifiers/SortingModifier.js
+++ b/src/modifiers/SortingModifier.js
@@ -9,13 +9,12 @@ class SortingModifier extends Modifier {
   /**
    * Create a SortingModifier
    *
-   * @param {string} notation The modifier notation
    * @param {string} [direction=a] The direction to sort in; either 'a' or 'd'
    *
    * @throws {RangeError} Direction must be 'a' or 'd'
    */
-  constructor(notation, direction = 'a') {
-    super(notation);
+  constructor(direction = 'a') {
+    super();
 
     this.direction = direction;
 
@@ -57,6 +56,15 @@ class SortingModifier extends Modifier {
     return 'sorting';
   }
   /* eslint-enable class-methods-use-this */
+
+  /**
+   * Returns the modifier notation
+   *
+   * @returns {string}
+   */
+  get notation() {
+    return `s${this.direction}`;
+  }
 
   /**
    * Runs the modifier on the rolls

--- a/src/modifiers/TargetModifier.js
+++ b/src/modifiers/TargetModifier.js
@@ -10,14 +10,13 @@ class TargetModifier extends ComparisonModifier {
   /**
    * Create a TargetModifier
    *
-   * @param {string} notation The modifier notation
    * @param {ComparePoint} successCP The success comparison object
    * @param {ComparePoint} [failureCP=null] The failure comparison object
    *
    * @throws {TypeError} failure comparePoint must be instance of ComparePoint or null
    */
-  constructor(notation, successCP, failureCP = null) {
-    super(notation, successCP);
+  constructor(successCP, failureCP = null) {
+    super(successCP);
 
     // set the failure compare point
     this.failureComparePoint = failureCP;
@@ -60,6 +59,15 @@ class TargetModifier extends ComparisonModifier {
     return 'target';
   }
   /* eslint-enable class-methods-use-this */
+
+  /**
+   * Returns the modifier notation
+   *
+   * @returns {string}
+   */
+  get notation() {
+    return `${super.notation}${this.failureComparePoint ? `f${this.failureComparePoint}` : ''}`;
+  }
 
   /**
    * Returns the success compare point for the modifier

--- a/src/parser/Parser.js
+++ b/src/parser/Parser.js
@@ -2,7 +2,7 @@ import * as parser from './grammars/grammar';
 import RequiredArgumentError from '../exceptions/RequiredArgumentError';
 
 /**
- * A DiceParser object that takes notations and parses them to rolls
+ * Takes notations and parses them to rolls
  */
 class Parser {
   /**

--- a/src/parser/grammars/grammar.pegjs
+++ b/src/parser/grammars/grammar.pegjs
@@ -34,17 +34,17 @@ Dice = die:(StandardDie / PercentileDie / FudgeDie) modifiers:Modifier* {
 
 StandardDie
   = qty:IntegerOrExpression? "d" sides:IntegerOrExpression {
-    return new Dice.StandardDice(text(), sides, qty || 1)
+    return new Dice.StandardDice(sides, qty || 1)
   }
 
 PercentileDie
   = qty:IntegerOrExpression? "d%" {
-    return new Dice.PercentileDice(text(), qty || 1);
+    return new Dice.PercentileDice(qty || 1);
   }
 
 FudgeDie
   = qty:IntegerOrExpression? "dF" sides:("." [12])? {
-    return new Dice.FudgeDice(text(), sides ? parseInt(sides[1], 10) : 2, qty || 1);
+    return new Dice.FudgeDice(sides ? parseInt(sides[1], 10) : 2, qty || 1);
   }
 
 
@@ -65,61 +65,61 @@ Modifier
 // Explode, Penetrate, Compound modifier
 ExplodeModifier
   = "!" compound:"!"? penetrate:"p"? comparePoint:ComparePoint? {
-    return new Modifiers.ExplodeModifier(text(), comparePoint, !!compound, !!penetrate);
+    return new Modifiers.ExplodeModifier(comparePoint, !!compound, !!penetrate);
   }
 
 // Target / Success and Failure modifier
 TargetModifier
   = successCP:ComparePoint failureCP:FailComparePoint? {
-    return new Modifiers.TargetModifier(text(), successCP, failureCP);
+    return new Modifiers.TargetModifier(successCP, failureCP);
   }
 
 // Drop lowest/highest dice) - needs alternative syntax of `"-" ("h" | "l")`
 DropModifier
   = "d" end:[lh]? qty:IntegerNumber {
-    return new Modifiers.DropModifier(text(), end || 'l', qty);
+    return new Modifiers.DropModifier(end || 'l', qty);
   }
 
 // Keep lowest/highest dice) - needs alternative syntax of `"+" ("h" | "l")`
 KeepModifier
   = "k" end:[lh]? qty:IntegerNumber {
-    return new Modifiers.KeepModifier(text(), end || 'h', qty);
+    return new Modifiers.KeepModifier(end || 'h', qty);
   }
 
 // Maximum roll value
 MaxModifier
   = "max" max:FloatNumber {
-    return new Modifiers.MaxModifier(text(), max);
+    return new Modifiers.MaxModifier(max);
   }
 
 // Minimum roll value
 MinModifier
   = "min" min:FloatNumber {
-    return new Modifiers.MinModifier(text(), min);
+    return new Modifiers.MinModifier(min);
   }
 
 // Re-rolling Dice (Including Re-roll Once)
 ReRollModifier
   = "r" once:"o"? comparePoint:ComparePoint? {
-    return new Modifiers.ReRollModifier(text(), !!once, comparePoint);
+    return new Modifiers.ReRollModifier(!!once, comparePoint);
   }
 
 // Critical success setting
 CriticalSuccessModifier
   = "cs" comparePoint:ComparePoint {
-    return new Modifiers.CriticalSuccessModifier(text(), comparePoint);
+    return new Modifiers.CriticalSuccessModifier(comparePoint);
   }
 
 // Critical failure setting
 CriticalFailureModifier
   = "cf" comparePoint:ComparePoint {
-    return new Modifiers.CriticalFailureModifier(text(), comparePoint);
+    return new Modifiers.CriticalFailureModifier(comparePoint);
   }
 
 // Sort rolls when outputting
 SortingModifier
   = "s" dir:("a" / "d")? {
-    return new Modifiers.SortingModifier(text(), dir || 'a');
+    return new Modifiers.SortingModifier(dir || 'a');
   }
 
 

--- a/tests/dice/FudgeDice.test.js
+++ b/tests/dice/FudgeDice.test.js
@@ -3,18 +3,19 @@ import RollResult from '../../src/results/RollResult';
 import RollResults from '../../src/results/RollResults';
 import Modifier from '../../src/modifiers/Modifier';
 import FudgeDice from '../../src/dice/FudgeDice';
-import RequiredArgumentError from '../../src/exceptions/RequiredArgumentError';
+import { ExplodeModifier, KeepModifier, SortingModifier } from '../../src/Modifiers';
+import ComparePoint from '../../src/ComparePoint';
 
 describe('FudgeDice', () => {
   describe('Initialisation', () => {
     test('model structure', () => {
-      const die = new FudgeDice('4dF');
+      const die = new FudgeDice();
 
       // assert that the die is a PercentileDie and that it extends StandardDice
       expect(die).toBeInstanceOf(FudgeDice);
       expect(die).toBeInstanceOf(StandardDice);
       expect(die).toEqual(expect.objectContaining({
-        notation: '4dF',
+        notation: '1dF.2',
         sides: 'F.2',
         qty: 1,
         modifiers: null,
@@ -28,154 +29,141 @@ describe('FudgeDice', () => {
         toString: expect.any(Function),
       }));
     });
-
-    test('constructor requires notation', () => {
-      expect(() => {
-        new FudgeDice();
-      }).toThrow(RequiredArgumentError);
-
-      expect(() => {
-        new FudgeDice(false);
-      }).toThrow(RequiredArgumentError);
-
-      expect(() => {
-        new FudgeDice(null);
-      }).toThrow(RequiredArgumentError);
-
-      expect(() => {
-        new FudgeDice(undefined);
-      }).toThrow(RequiredArgumentError);
-    });
   });
 
   describe('Sides / non-blanks', () => {
     test('no sides default to 2', () => {
-      let die = new FudgeDice('4dF');
+      let die = new FudgeDice();
 
       expect(die.nonBlanks).toBe(2);
       expect(die.sides).toEqual('F.2');
 
-      die = new FudgeDice('4dF', null);
+      die = new FudgeDice(null);
 
       expect(die.nonBlanks).toBe(2);
       expect(die.sides).toEqual('F.2');
 
-      die = new FudgeDice('4dF', false);
+      die = new FudgeDice(false);
 
       expect(die.nonBlanks).toBe(2);
       expect(die.sides).toEqual('F.2');
     });
 
     test('can set sides to 2', () => {
-      const die = new FudgeDice('4dF', 2);
+      const die = new FudgeDice(2);
       expect(die.sides).toEqual('F.2');
       expect(die.nonBlanks).toBe(2);
+      expect(die.notation).toEqual('1dF.2');
     });
 
     test('can set sides to 1', () => {
-      const die = new FudgeDice('4dF', 1);
+      const die = new FudgeDice(1);
       expect(die.sides).toEqual('F.1');
       expect(die.nonBlanks).toBe(1);
+      expect(die.notation).toEqual('1dF.1');
     });
 
     test('sides must be 1 or 2', () => {
       expect(() => {
-        new FudgeDice('4dF', 0);
+        new FudgeDice(0);
       }).toThrow(RangeError);
 
       expect(() => {
-        new FudgeDice('4dF', 3);
+        new FudgeDice(3);
       }).toThrow(RangeError);
 
       expect(() => {
-        new FudgeDice('4dF', -1);
+        new FudgeDice(-1);
       }).toThrow(RangeError);
 
       expect(() => {
-        new FudgeDice('4dF', 6);
+        new FudgeDice(6);
       }).toThrow(RangeError);
 
       expect(() => {
-        new FudgeDice('4dF', []);
+        new FudgeDice([]);
       }).toThrow(RangeError);
 
       expect(() => {
-        new FudgeDice('4dF', { nonBlanks: 2 });
+        new FudgeDice({ nonBlanks: 2 });
       }).toThrow(RangeError);
 
       expect(() => {
-        new FudgeDice('4dF', 'foo');
+        new FudgeDice('foo');
       }).toThrow(RangeError);
     });
   });
 
   describe('Quantity', () => {
     test('qty must be numeric', () => {
-      let die = new FudgeDice('4dF', null, 8);
+      let die = new FudgeDice(null, 8);
       expect(die.qty).toBe(8);
+      expect(die.notation).toEqual('8dF.2');
 
       expect(() => {
-        die = new FudgeDice('4dF', null, 'foo');
+        die = new FudgeDice(null, 'foo');
       }).toThrow(TypeError);
 
       expect(() => {
-        die = new FudgeDice('4dF', null, false);
+        die = new FudgeDice(null, false);
       }).toThrow(TypeError);
 
       expect(() => {
-        die = new FudgeDice('4dF', null, true);
+        die = new FudgeDice(null, true);
       }).toThrow(TypeError);
 
       expect(() => {
-        die = new FudgeDice('4dF', null, []);
+        die = new FudgeDice(null, []);
       }).toThrow(TypeError);
 
       expect(() => {
-        die = new FudgeDice('4dF', null, { qty: 4 });
+        die = new FudgeDice(null, { qty: 4 });
       }).toThrow(TypeError);
     });
 
     test('qty must be positive non-zero', () => {
-      let die = new FudgeDice('4dF', null, 1);
+      let die = new FudgeDice(null, 1);
       expect(die.qty).toBe(1);
+      expect(die.notation).toEqual('1dF.2');
 
-      die = new FudgeDice('4dF', null, 324);
+      die = new FudgeDice(null, 324);
       expect(die.qty).toBe(324);
+      expect(die.notation).toEqual('324dF.2');
 
       expect(() => {
-        die = new FudgeDice('4dF', null, 0);
+        die = new FudgeDice(null, 0);
       }).toThrow(RangeError);
 
       expect(() => {
-        die = new FudgeDice('4dF', null, -42);
+        die = new FudgeDice(null, -42);
       }).toThrow(RangeError);
 
       expect(() => {
-        die = new FudgeDice('4dF', null, -1);
+        die = new FudgeDice(null, -1);
       }).toThrow(RangeError);
     });
   });
 
   describe('Average', () => {
     test('average is correct for single die', () => {
-      let die = new FudgeDice('dF');
+      let die = new FudgeDice();
       expect(die.average).toBe(0);
 
-      die = new FudgeDice('dF.1', 1);
+      die = new FudgeDice(1);
       expect(die.average).toBe(0);
     });
 
     test('average is unaffected when rolling multiple', () => {
-      let die = new FudgeDice('2dF', 2, 2);
+      let die = new FudgeDice(2, 2);
       expect(die.average).toBe(0);
 
-      die = new FudgeDice('400dF', 2, 400);
+      die = new FudgeDice(2, 400);
       expect(die.average).toBe(0);
 
-      die = new FudgeDice('56dF.1', 1, 56);
+      die = new FudgeDice(1, 56);
       expect(die.average).toBe(0);
 
-      die = new FudgeDice('145dF.1', 1, 145);
+      die = new FudgeDice(1, 145);
       expect(die.average).toBe(0);
     });
   });
@@ -185,7 +173,7 @@ describe('FudgeDice', () => {
       const spy = jest.spyOn(FudgeDice.prototype, 'modifiers', 'set');
       const modifiers = new Map(Object.entries({ foo: new Modifier('m') }));
 
-      new FudgeDice('4dF', null, 1, modifiers);
+      new FudgeDice(null, 1, modifiers);
 
       expect(spy).toHaveBeenCalledTimes(1);
 
@@ -195,7 +183,7 @@ describe('FudgeDice', () => {
 
     test('can set modifiers with Map', () => {
       const modifiers = new Map(Object.entries({ foo: new Modifier('m') }));
-      const die = new FudgeDice('4dF', null, 1);
+      const die = new FudgeDice(null, 1);
 
       die.modifiers = modifiers;
 
@@ -205,7 +193,7 @@ describe('FudgeDice', () => {
 
     test('can set modifiers with Object', () => {
       const modifier = new Modifier('m');
-      const die = new FudgeDice('4dF', null, 1);
+      const die = new FudgeDice(null, 1);
 
       die.modifiers = { foo: modifier };
 
@@ -215,7 +203,7 @@ describe('FudgeDice', () => {
 
     test('can set modifiers with Array', () => {
       const modifiers = [new Modifier('m')];
-      const die = new FudgeDice('4dF', null, 1);
+      const die = new FudgeDice(null, 1);
 
       die.modifiers = modifiers;
 
@@ -225,26 +213,26 @@ describe('FudgeDice', () => {
 
     test('throws error if modifiers type is invalid', () => {
       expect(() => {
-        new FudgeDice('4dF', null, 1, 'foo');
+        new FudgeDice(null, 1, 'foo');
       }).toThrow(TypeError);
 
       expect(() => {
-        new FudgeDice('4dF', null, 1, 351);
+        new FudgeDice(null, 1, 351);
       }).toThrow(TypeError);
 
       expect(() => {
         const modifiers = new Map(Object.entries({ foo: 'bar' }));
-        new FudgeDice('4dF', null, 1, modifiers);
+        new FudgeDice(null, 1, modifiers);
       }).toThrow(TypeError);
 
       expect(() => {
         const modifiers = { foo: 'bar' };
-        new FudgeDice('4dF', null, 1, modifiers);
+        new FudgeDice(null, 1, modifiers);
       }).toThrow(TypeError);
 
       expect(() => {
         const modifiers = ['bar'];
-        new FudgeDice('4dF', null, 1, modifiers);
+        new FudgeDice(null, 1, modifiers);
       }).toThrow(TypeError);
     });
 
@@ -260,7 +248,7 @@ describe('FudgeDice', () => {
       mod4.order = 2;
 
       // create the dice instance
-      const die = new FudgeDice('4dF', null, 4);
+      const die = new FudgeDice(null, 4);
 
       die.modifiers = {
         mod1, mod2, mod3, mod4,
@@ -276,9 +264,34 @@ describe('FudgeDice', () => {
     });
   });
 
+  describe('Notation', () => {
+    test('simple notation', () => {
+      let die = new FudgeDice(2, 45);
+      expect(die.notation).toEqual('45dF.2');
+
+      die = new FudgeDice(1, 999);
+      expect(die.notation).toEqual('999dF.1');
+
+      die = new FudgeDice(null, 10);
+      expect(die.notation).toEqual('10dF.2');
+    });
+
+    test('notation with modifiers', () => {
+      const modifiers = [
+        new KeepModifier('h', 1),
+        new SortingModifier(),
+        new ExplodeModifier(new ComparePoint('>', 3)),
+      ];
+
+      const die = new FudgeDice(1, 36, modifiers);
+
+      expect(die.notation).toEqual('36dF.1!>3kh1sa');
+    });
+  });
+
   describe('Output', () => {
     test('JSON output is correct', () => {
-      const die = new FudgeDice('4dF', null, 4);
+      const die = new FudgeDice(null, 4);
 
       // json encode, to get the encoded string, then decode so we can compare the object
       // this allows us to check that the output is correct, but ignoring the order of the
@@ -289,7 +302,7 @@ describe('FudgeDice', () => {
         min: -1,
         modifiers: null,
         name: 'fudge',
-        notation: '4dF',
+        notation: '4dF.2',
         qty: 4,
         sides: 'F.2',
         type: 'die',
@@ -297,11 +310,11 @@ describe('FudgeDice', () => {
     });
 
     test('String output is correct', () => {
-      let die = new FudgeDice('4dF', null, 4);
+      let die = new FudgeDice(null, 4);
 
-      expect(die.toString()).toEqual('4dF');
+      expect(die.toString()).toEqual('4dF.2');
 
-      die = new FudgeDice('4dF.1', 1, 4);
+      die = new FudgeDice(1, 4);
 
       expect(die.toString()).toEqual('4dF.1');
     });
@@ -309,11 +322,11 @@ describe('FudgeDice', () => {
 
   describe('Rolling', () => {
     test('rollOnce returns a RollResult object', () => {
-      expect((new FudgeDice('1dF.2', 2, 1)).rollOnce()).toBeInstanceOf(RollResult);
+      expect((new FudgeDice(2, 1)).rollOnce()).toBeInstanceOf(RollResult);
     });
 
     test('rollOnce rolls between min and max (Inclusive)', () => {
-      const die = new FudgeDice('1dF.2', 2, 1);
+      const die = new FudgeDice(2, 1);
       const iterations = 1000;
 
       // run the test multiple times to try and ensure consistency
@@ -326,7 +339,7 @@ describe('FudgeDice', () => {
     });
 
     test('rollOnce rolls between min and max (Inclusive) for F.1', () => {
-      const die = new FudgeDice('1dF.1', 1, 1);
+      const die = new FudgeDice(1, 1);
       const iterations = 1000;
 
       // run the test multiple times to try and ensure consistency
@@ -339,11 +352,11 @@ describe('FudgeDice', () => {
     });
 
     test('roll returns a RollResults object', () => {
-      expect((new FudgeDice('4dF', null, 1)).roll()).toBeInstanceOf(RollResults);
+      expect((new FudgeDice(null, 1)).roll()).toBeInstanceOf(RollResults);
     });
 
     test('rollOnce gets called when rolling', () => {
-      const die = new FudgeDice('4dF', null, 4);
+      const die = new FudgeDice(null, 4);
       // create a spy to listen for the Model.rollOnce method to have been triggered
       const spy = jest.spyOn(die, 'rollOnce');
 
@@ -357,7 +370,7 @@ describe('FudgeDice', () => {
     });
 
     test('roll returns correct number of rolls', () => {
-      const die = new FudgeDice('4dF', null, 4);
+      const die = new FudgeDice(null, 4);
 
       expect(die.roll()).toHaveLength(4);
     });
@@ -365,7 +378,7 @@ describe('FudgeDice', () => {
 
   describe('Readonly properties', () => {
     test('cannot change max value', () => {
-      const die = new FudgeDice('4dF', null, 4);
+      const die = new FudgeDice(null, 4);
 
       expect(() => {
         die.max = 450;
@@ -373,7 +386,7 @@ describe('FudgeDice', () => {
     });
 
     test('cannot change min value', () => {
-      const die = new FudgeDice('4dF', null, 4);
+      const die = new FudgeDice(null, 4);
 
       expect(() => {
         die.min = 450;
@@ -381,7 +394,7 @@ describe('FudgeDice', () => {
     });
 
     test('cannot change name value', () => {
-      const die = new FudgeDice('4dF', null, 4);
+      const die = new FudgeDice(null, 4);
 
       expect(() => {
         die.name = 'Foo';
@@ -389,7 +402,7 @@ describe('FudgeDice', () => {
     });
 
     test('cannot change notation value', () => {
-      const die = new FudgeDice('4dF', null, 4);
+      const die = new FudgeDice(null, 4);
 
       expect(() => {
         die.notation = '6d4';
@@ -397,7 +410,7 @@ describe('FudgeDice', () => {
     });
 
     test('cannot change qty value', () => {
-      const die = new FudgeDice('4dF', null, 4);
+      const die = new FudgeDice(null, 4);
 
       expect(() => {
         die.qty = 6;
@@ -405,7 +418,7 @@ describe('FudgeDice', () => {
     });
 
     test('cannot change sides value', () => {
-      const die = new FudgeDice('4dF', null, 4);
+      const die = new FudgeDice(null, 4);
 
       expect(() => {
         die.sides = 2;
@@ -413,7 +426,7 @@ describe('FudgeDice', () => {
     });
 
     test('cannot change nonBlanks value', () => {
-      const die = new FudgeDice('4dF', 1, 4);
+      const die = new FudgeDice(1, 4);
 
       expect(() => {
         die.nonBlanks = 2;

--- a/tests/dice/StandardDice.test.js
+++ b/tests/dice/StandardDice.test.js
@@ -1,13 +1,15 @@
+import { ExplodeModifier, SortingModifier } from '../../src/Modifiers';
+import ComparePoint from '../../src/ComparePoint';
+import Modifier from '../../src/modifiers/Modifier';
 import StandardDice from '../../src/dice/StandardDice';
 import RollResult from '../../src/results/RollResult';
 import RollResults from '../../src/results/RollResults';
-import Modifier from '../../src/modifiers/Modifier';
 import RequiredArgumentError from '../../src/exceptions/RequiredArgumentError';
 
 describe('StandardDice', () => {
   describe('Initialisation', () => {
     test('model structure', () => {
-      const die = new StandardDice('4d6', 6, 4);
+      const die = new StandardDice(6, 4);
 
       expect(die).toBeInstanceOf(StandardDice);
       expect(die).toEqual(expect.objectContaining({
@@ -25,7 +27,7 @@ describe('StandardDice', () => {
       }));
     });
 
-    test('constructor requires notation', () => {
+    test('constructor requires sides', () => {
       expect(() => {
         new StandardDice();
       }).toThrow(RequiredArgumentError);
@@ -43,32 +45,14 @@ describe('StandardDice', () => {
       }).toThrow(RequiredArgumentError);
     });
 
-    test('constructor requires sides', () => {
-      expect(() => {
-        new StandardDice('1d6');
-      }).toThrow(RequiredArgumentError);
-
-      expect(() => {
-        new StandardDice('1d6', false);
-      }).toThrow(RequiredArgumentError);
-
-      expect(() => {
-        new StandardDice('1d6', null);
-      }).toThrow(RequiredArgumentError);
-
-      expect(() => {
-        new StandardDice('1d6', undefined);
-      }).toThrow(RequiredArgumentError);
-    });
-
     test('can set `min` in constructor', () => {
-      const die = new StandardDice('4d6', 6, 4, null, 3);
+      const die = new StandardDice(6, 4, null, 3);
 
       expect(die.min).toBe(3);
     });
 
     test('can set `max` in constructor', () => {
-      const die = new StandardDice('4d6', 6, 4, null, 1, 8);
+      const die = new StandardDice(6, 4, null, 1, 8);
 
       expect(die.max).toBe(8);
     });
@@ -76,71 +60,71 @@ describe('StandardDice', () => {
 
   describe('Sides', () => {
     test('must be numeric or string', () => {
-      let die = new StandardDice('d1', 1);
+      let die = new StandardDice(1);
       expect(die.sides).toBe(1);
 
-      die = new StandardDice('d9', 'foo');
+      die = new StandardDice('foo');
       expect(die.sides).toBe('foo');
 
       expect(() => {
-        new StandardDice('d6', {});
+        new StandardDice({});
       }).toThrow(TypeError);
 
       expect(() => {
-        new StandardDice('d6', []);
+        new StandardDice([]);
       }).toThrow(TypeError);
     });
 
     describe('If numeric...', () => {
       test('must be positive non-zero', () => {
-        let die = new StandardDice('d1', 1);
-        expect(die.sides).toBe(1);
+        let die = new StandardDice(45);
+        expect(die.sides).toBe(45);
 
-        die = new StandardDice('d9', 9);
+        die = new StandardDice(9);
         expect(die.sides).toBe(9);
 
-        die = new StandardDice('d689', 689);
+        die = new StandardDice(689);
         expect(die.sides).toBe(689);
 
         expect(() => {
-          new StandardDice('d6', 0);
+          new StandardDice(0);
         }).toThrow(RangeError);
 
         expect(() => {
-          new StandardDice('d6', -42);
+          new StandardDice(-42);
         }).toThrow(RangeError);
 
         expect(() => {
-          new StandardDice('d6', -1);
+          new StandardDice(-1);
         }).toThrow(RangeError);
       });
 
       test('can be float', () => {
-        let die = new StandardDice('d1', 5.67);
+        let die = new StandardDice(5.67);
         expect(die.sides).toBeCloseTo(5.67);
 
-        die = new StandardDice('d9', 589.138);
+        die = new StandardDice(589.138);
         expect(die.sides).toBeCloseTo(589.138);
 
-        die = new StandardDice('d9', 13.5);
+        die = new StandardDice(13.5);
         expect(die.sides).toBeCloseTo(13.5);
       });
 
       test('must be finite', () => {
         expect(() => {
-          new StandardDice('4d6', Infinity);
+          new StandardDice(Infinity);
         }).toThrow(RangeError);
       });
 
       describe('"Safe" number', () => {
         test('can be equal to `Number.MAX_SAFE_INTEGER`', () => {
-          const die = new StandardDice('4d6', Number.MAX_SAFE_INTEGER);
+          const die = new StandardDice(Number.MAX_SAFE_INTEGER);
           expect(die.sides).toBe(Number.MAX_SAFE_INTEGER);
         });
 
         test('cannot be greater than `Number.MAX_SAFE_INTEGER`', () => {
           expect(() => {
-            new StandardDice('4d6', Number.MAX_SAFE_INTEGER + 1);
+            new StandardDice(Number.MAX_SAFE_INTEGER + 1);
           }).toThrow(RangeError);
         });
       });
@@ -149,155 +133,155 @@ describe('StandardDice', () => {
 
   describe('Quantity', () => {
     test('must be numeric', () => {
-      let die = new StandardDice('4d6', 6, 8);
+      let die = new StandardDice(6, 8);
       expect(die.qty).toBe(8);
 
       expect(() => {
-        die = new StandardDice('4d6', 6, 'foo');
+        die = new StandardDice(6, 'foo');
       }).toThrow(TypeError);
 
       expect(() => {
-        die = new StandardDice('4d6', 6, false);
+        die = new StandardDice(6, false);
       }).toThrow(TypeError);
 
       expect(() => {
-        die = new StandardDice('4d6', 6, true);
+        die = new StandardDice(6, true);
       }).toThrow(TypeError);
 
       expect(() => {
-        die = new StandardDice('4d6', 6, []);
+        die = new StandardDice(6, []);
       }).toThrow(TypeError);
 
       expect(() => {
-        die = new StandardDice('4d6', 6, { qty: 4 });
+        die = new StandardDice(6, { qty: 4 });
       }).toThrow(TypeError);
     });
 
     test('must be positive non-zero', () => {
-      let die = new StandardDice('4d6', 6, 1);
+      let die = new StandardDice(6, 1);
       expect(die.qty).toBe(1);
 
-      die = new StandardDice('324d6', 6, 324);
+      die = new StandardDice(6, 324);
       expect(die.qty).toBe(324);
 
       expect(() => {
-        die = new StandardDice('4d6', 6, 0);
+        die = new StandardDice(6, 0);
       }).toThrow(RangeError);
 
       expect(() => {
-        die = new StandardDice('4d6', 6, -42);
+        die = new StandardDice(6, -42);
       }).toThrow(RangeError);
 
       expect(() => {
-        die = new StandardDice('4d6', 6, -1);
+        die = new StandardDice(6, -1);
       }).toThrow(RangeError);
     });
 
     test('cannot be greater than 999', () => {
-      let die = new StandardDice('4d6', 6, 999);
+      let die = new StandardDice(6, 999);
       expect(die.qty).toBe(999);
 
-      die = new StandardDice('324d6', 6, 998);
+      die = new StandardDice(6, 998);
       expect(die.qty).toBe(998);
 
       expect(() => {
-        die = new StandardDice('4d6', 6, 1000);
+        die = new StandardDice(6, 1000);
       }).toThrow(RangeError);
 
       expect(() => {
-        die = new StandardDice('4d6', 6, 1001);
+        die = new StandardDice(6, 1001);
       }).toThrow(RangeError);
 
       expect(() => {
-        die = new StandardDice('4d6', 6, 50000);
+        die = new StandardDice(6, 50000);
       }).toThrow(RangeError);
 
       expect(() => {
-        die = new StandardDice('4d6', 6, 9999);
+        die = new StandardDice(6, 9999);
       }).toThrow(RangeError);
     });
 
     test('float values are floored to integer', () => {
-      let die = new StandardDice('4d6', 6, 8.1);
+      let die = new StandardDice(6, 8.1);
       expect(die.qty).toBe(8);
 
-      die = new StandardDice('4d6', 6, 5.9);
+      die = new StandardDice(6, 5.9);
       expect(die.qty).toBe(5);
 
-      die = new StandardDice('4d6', 6, 67.5);
+      die = new StandardDice(6, 67.5);
       expect(die.qty).toBe(67);
     });
 
     test('must be finite', () => {
       expect(() => {
-        new StandardDice('4d6', 6, Infinity);
+        new StandardDice(6, Infinity);
       }).toThrow(TypeError);
     });
   });
 
   describe('Min', () => {
     test('must be numeric', () => {
-      const die = new StandardDice('4d6', 6, 8, null, 3);
+      const die = new StandardDice(6, 8, null, 3);
       expect(die.min).toBe(3);
 
       expect(() => {
-        new StandardDice('4d6', 6, 8, null, 'foo');
+        new StandardDice(6, 8, null, 'foo');
       }).toThrow(TypeError);
 
       expect(() => {
-        new StandardDice('4d6', 6, 8, null, false);
+        new StandardDice(6, 8, null, false);
       }).toThrow(TypeError);
 
       expect(() => {
-        new StandardDice('4d6', 6, 8, null, true);
+        new StandardDice(6, 8, null, true);
       }).toThrow(TypeError);
 
       expect(() => {
-        new StandardDice('4d6', 6, 8, null, []);
+        new StandardDice(6, 8, null, []);
       }).toThrow(TypeError);
 
       expect(() => {
-        new StandardDice('4d6', 6, 8, null, { min: 4 });
+        new StandardDice(6, 8, null, { min: 4 });
       }).toThrow(TypeError);
     });
 
     test('float values are floored to integer', () => {
-      let die = new StandardDice('4d6', 6, 4, null, 4.23);
+      let die = new StandardDice(6, 4, null, 4.23);
       expect(die.min).toBe(4);
 
-      die = new StandardDice('4d6', 6, 4, null, -14.78);
+      die = new StandardDice(6, 4, null, -14.78);
       expect(die.min).toBe(-14);
 
-      die = new StandardDice('4d6', 6, 4, null, 145.5);
+      die = new StandardDice(6, 4, null, 145.5);
       expect(die.min).toBe(145);
     });
 
     test('must be finite', () => {
       expect(() => {
-        new StandardDice('4d6', 6, 4, null, Infinity);
+        new StandardDice(6, 4, null, Infinity);
       }).toThrow(TypeError);
     });
 
     describe('"Safe" number', () => {
       test('can be equal to `Number.MAX_SAFE_INTEGER`', () => {
-        const die = new StandardDice('4d6', 6, 4, null, Number.MAX_SAFE_INTEGER);
+        const die = new StandardDice(6, 4, null, Number.MAX_SAFE_INTEGER);
         expect(die.min).toBe(Number.MAX_SAFE_INTEGER);
       });
 
       test('cannot be greater than `Number.MAX_SAFE_INTEGER`', () => {
         expect(() => {
-          new StandardDice('4d6', 6, 4, null, Number.MAX_SAFE_INTEGER + 1);
+          new StandardDice(6, 4, null, Number.MAX_SAFE_INTEGER + 1);
         }).toThrow(RangeError);
       });
 
       test('can be equal to `Number.MIN_SAFE_INTEGER`', () => {
-        const die = new StandardDice('4d6', 6, 4, null, Number.MIN_SAFE_INTEGER);
+        const die = new StandardDice(6, 4, null, Number.MIN_SAFE_INTEGER);
         expect(die.min).toBe(Number.MIN_SAFE_INTEGER);
       });
 
       test('cannot be less than `Number.MIN_SAFE_INTEGER`', () => {
         expect(() => {
-          new StandardDice('4d6', 6, 4, null, Number.MIN_SAFE_INTEGER - 1);
+          new StandardDice(6, 4, null, Number.MIN_SAFE_INTEGER - 1);
         }).toThrow(RangeError);
       });
     });
@@ -305,67 +289,67 @@ describe('StandardDice', () => {
 
   describe('Max', () => {
     test('falsey is treated as value of sides', () => {
-      let die = new StandardDice('4d6', 6, 4, null, 1, false);
+      let die = new StandardDice(6, 4, null, 1, false);
       expect(die.max).toBe(6);
 
-      die = new StandardDice('4d6', 6, 4, null, 1, null);
+      die = new StandardDice(6, 4, null, 1, null);
       expect(die.max).toBe(6);
 
-      die = new StandardDice('4d6', 6, 4, null, 1, undefined);
+      die = new StandardDice(6, 4, null, 1, undefined);
       expect(die.max).toBe(6);
     });
 
     test('non-numeric throws an error', () => {
       expect(() => {
-        new StandardDice('4d6', 6, 4, null, 1, 'foo');
+        new StandardDice(6, 4, null, 1, 'foo');
       }).toThrow(TypeError);
 
       expect(() => {
-        new StandardDice('4d6', 6, 4, null, 1, []);
+        new StandardDice(6, 4, null, 1, []);
       }).toThrow(TypeError);
 
       expect(() => {
-        new StandardDice('4d6', 6, 4, null, 1, {});
+        new StandardDice(6, 4, null, 1, {});
       }).toThrow(TypeError);
     });
 
     test('float values are floored to integer', () => {
-      let die = new StandardDice('4d6', 6, 4, null, 1, 65.143);
+      let die = new StandardDice(6, 4, null, 1, 65.143);
       expect(die.max).toBe(65);
 
-      die = new StandardDice('4d6', 6, 4, null, 1, -578.891);
+      die = new StandardDice(6, 4, null, 1, -578.891);
       expect(die.max).toBe(-578);
 
-      die = new StandardDice('4d6', 6, 4, null, 1, 4.5);
+      die = new StandardDice(6, 4, null, 1, 4.5);
       expect(die.max).toBe(4);
     });
 
     test('must be finite', () => {
       expect(() => {
-        new StandardDice('4d6', 6, 4, null, 1, Infinity);
+        new StandardDice(6, 4, null, 1, Infinity);
       }).toThrow(TypeError);
     });
 
     describe('"Safe" number', () => {
       test('can be equal to `Number.MAX_SAFE_INTEGER`', () => {
-        const die = new StandardDice('4d6', 6, 4, null, 1, Number.MAX_SAFE_INTEGER);
+        const die = new StandardDice(6, 4, null, 1, Number.MAX_SAFE_INTEGER);
         expect(die.max).toBe(Number.MAX_SAFE_INTEGER);
       });
 
       test('cannot be greater than `Number.MAX_SAFE_INTEGER`', () => {
         expect(() => {
-          new StandardDice('4d6', 6, 4, null, 1, Number.MAX_SAFE_INTEGER + 1);
+          new StandardDice(6, 4, null, 1, Number.MAX_SAFE_INTEGER + 1);
         }).toThrow(RangeError);
       });
 
       test('can be equal to `Number.MIN_SAFE_INTEGER`', () => {
-        const die = new StandardDice('4d6', 6, 4, null, 1, Number.MIN_SAFE_INTEGER);
+        const die = new StandardDice(6, 4, null, 1, Number.MIN_SAFE_INTEGER);
         expect(die.max).toBe(Number.MIN_SAFE_INTEGER);
       });
 
       test('cannot be less than `Number.MIN_SAFE_INTEGER`', () => {
         expect(() => {
-          new StandardDice('4d6', 6, 4, null, 1, Number.MIN_SAFE_INTEGER - 1);
+          new StandardDice(6, 4, null, 1, Number.MIN_SAFE_INTEGER - 1);
         }).toThrow(RangeError);
       });
     });
@@ -373,36 +357,36 @@ describe('StandardDice', () => {
 
   describe('Average', () => {
     test('average is correct for single die', () => {
-      let die = new StandardDice('d3', 3, 1);
+      let die = new StandardDice(3, 1);
       expect(die.average).toBe(2);
 
-      die = new StandardDice('d10', 10, 1);
+      die = new StandardDice(10, 1);
       expect(die.average).toBe(5.5);
 
-      die = new StandardDice('d1', 1, 1);
+      die = new StandardDice(1, 1);
       expect(die.average).toBe(1);
 
-      die = new StandardDice('d20', 20, 1);
+      die = new StandardDice(20, 1);
       expect(die.average).toBe(10.5);
 
-      die = new StandardDice('d45', 45, 1);
+      die = new StandardDice(45, 1);
       expect(die.average).toBe(23);
     });
 
     test('average is unaffected when rolling multiple', () => {
-      let die = new StandardDice('2d3', 3, 2);
+      let die = new StandardDice(3, 2);
       expect(die.average).toBe(2);
 
-      die = new StandardDice('400d10', 10, 400);
+      die = new StandardDice(10, 400);
       expect(die.average).toBe(5.5);
 
-      die = new StandardDice('56d1', 1, 56);
+      die = new StandardDice(1, 56);
       expect(die.average).toBe(1);
 
-      die = new StandardDice('12d20', 20, 12);
+      die = new StandardDice(20, 12);
       expect(die.average).toBe(10.5);
 
-      die = new StandardDice('145d45', 45, 145);
+      die = new StandardDice(45, 145);
       expect(die.average).toBe(23);
     });
   });
@@ -412,7 +396,7 @@ describe('StandardDice', () => {
       const spy = jest.spyOn(StandardDice.prototype, 'modifiers', 'set');
       const modifiers = new Map(Object.entries({ foo: new Modifier('m') }));
 
-      new StandardDice('4d6', 6, 8, modifiers);
+      new StandardDice(6, 8, modifiers);
 
       expect(spy).toHaveBeenCalledTimes(1);
 
@@ -422,7 +406,7 @@ describe('StandardDice', () => {
 
     test('can set modifiers with Map', () => {
       const modifiers = new Map(Object.entries({ foo: new Modifier('m') }));
-      const die = new StandardDice('4d6', 6, 8);
+      const die = new StandardDice(6, 8);
 
       die.modifiers = modifiers;
 
@@ -432,7 +416,7 @@ describe('StandardDice', () => {
 
     test('can set modifiers with Object', () => {
       const modifier = new Modifier('m');
-      const die = new StandardDice('4d6', 6, 8);
+      const die = new StandardDice(6, 8);
 
       die.modifiers = { foo: modifier };
 
@@ -442,7 +426,7 @@ describe('StandardDice', () => {
 
     test('can set modifiers with Array', () => {
       const modifiers = [new Modifier('m')];
-      const die = new StandardDice('4d6', 6, 8);
+      const die = new StandardDice(6, 8);
 
       die.modifiers = modifiers;
 
@@ -452,26 +436,26 @@ describe('StandardDice', () => {
 
     test('throws error if modifiers type is invalid', () => {
       expect(() => {
-        new StandardDice('4d6', 6, 8, 'foo');
+        new StandardDice(6, 8, 'foo');
       }).toThrow(TypeError);
 
       expect(() => {
-        new StandardDice('4d6', 6, 8, 351);
+        new StandardDice(6, 8, 351);
       }).toThrow(TypeError);
 
       expect(() => {
         const modifiers = new Map(Object.entries({ foo: 'bar' }));
-        new StandardDice('4d6', 6, 8, modifiers);
+        new StandardDice(6, 8, modifiers);
       }).toThrow(TypeError);
 
       expect(() => {
         const modifiers = { foo: 'bar' };
-        new StandardDice('4d6', 6, 8, modifiers);
+        new StandardDice(6, 8, modifiers);
       }).toThrow(TypeError);
 
       expect(() => {
         const modifiers = ['bar'];
-        new StandardDice('4d6', 6, 8, modifiers);
+        new StandardDice(6, 8, modifiers);
       }).toThrow(TypeError);
     });
 
@@ -487,7 +471,7 @@ describe('StandardDice', () => {
       mod4.order = 2;
 
       // create the dice instance
-      const die = new StandardDice('4d6', 6, 8);
+      const die = new StandardDice(6, 8);
 
       die.modifiers = {
         mod1, mod2, mod3, mod4,
@@ -503,9 +487,33 @@ describe('StandardDice', () => {
     });
   });
 
+  describe('Notation', () => {
+    test('simple notation', () => {
+      let die = new StandardDice(45, 167);
+      expect(die.notation).toEqual('167d45');
+
+      die = new StandardDice(20, 999);
+      expect(die.notation).toEqual('999d20');
+
+      die = new StandardDice(1, 10);
+      expect(die.notation).toEqual('10d1');
+    });
+
+    test('notation with modifiers', () => {
+      const modifiers = [
+        new SortingModifier(),
+        new ExplodeModifier(new ComparePoint('>', 3)),
+      ];
+
+      const die = new StandardDice(45, 167, modifiers);
+
+      expect(die.notation).toEqual('167d45!>3sa');
+    });
+  });
+
   describe('Output', () => {
     test('JSON output is correct', () => {
-      const die = new StandardDice('4d6', 6, 4);
+      const die = new StandardDice(6, 4);
 
       // json encode, to get the encoded string, then decode so we can compare the object
       // this allows us to check that the output is correct, but ignoring the order of the
@@ -524,7 +532,7 @@ describe('StandardDice', () => {
     });
 
     test('String output is correct', () => {
-      const die = new StandardDice('4d6', 6, 4);
+      const die = new StandardDice(6, 4);
 
       expect(die.toString()).toEqual('4d6');
     });
@@ -532,11 +540,11 @@ describe('StandardDice', () => {
 
   describe('Rolling', () => {
     test('rollOnce returns a RollResult object', () => {
-      expect((new StandardDice('1d6', 6)).rollOnce()).toBeInstanceOf(RollResult);
+      expect((new StandardDice(6)).rollOnce()).toBeInstanceOf(RollResult);
     });
 
     test('rollOnce rolls between min and max (Inclusive)', () => {
-      const die = new StandardDice('1d6', 6);
+      const die = new StandardDice(6);
       const iterations = 1000;
 
       // run the test multiple times to try and ensure consistency
@@ -549,13 +557,13 @@ describe('StandardDice', () => {
     });
 
     test('roll return a RollResults object', () => {
-      expect((new StandardDice('1d6', 6)).roll()).toBeInstanceOf(RollResults);
+      expect((new StandardDice(6)).roll()).toBeInstanceOf(RollResults);
     });
 
     test('rollOnce gets called when rolling', () => {
       // create a spy to listen for the Model.rollOnce method to have been triggered
       const spy = jest.spyOn(StandardDice.prototype, 'rollOnce');
-      const die = new StandardDice('4d6', 6, 4);
+      const die = new StandardDice(6, 4);
 
       // roll the dice
       die.roll();
@@ -567,7 +575,7 @@ describe('StandardDice', () => {
     });
 
     test('roll returns correct number of rolls', () => {
-      const die = new StandardDice('4d6', 6, 4);
+      const die = new StandardDice(6, 4);
 
       expect(die.roll()).toHaveLength(4);
     });
@@ -575,7 +583,7 @@ describe('StandardDice', () => {
 
   describe('Readonly properties', () => {
     test('cannot change max value', () => {
-      const die = new StandardDice('4d6', 6, 4);
+      const die = new StandardDice(6, 4);
 
       expect(() => {
         die.max = 450;
@@ -583,7 +591,7 @@ describe('StandardDice', () => {
     });
 
     test('cannot change min value', () => {
-      const die = new StandardDice('4d6', 6, 4);
+      const die = new StandardDice(6, 4);
 
       expect(() => {
         die.min = 450;
@@ -591,7 +599,7 @@ describe('StandardDice', () => {
     });
 
     test('cannot change name value', () => {
-      const die = new StandardDice('4d6', 6, 4);
+      const die = new StandardDice(6, 4);
 
       expect(() => {
         die.name = 'Foo';
@@ -599,7 +607,7 @@ describe('StandardDice', () => {
     });
 
     test('cannot change notation value', () => {
-      const die = new StandardDice('4d6', 6, 4);
+      const die = new StandardDice(6, 4);
 
       expect(() => {
         die.notation = '6d4';
@@ -607,7 +615,7 @@ describe('StandardDice', () => {
     });
 
     test('cannot change qty value', () => {
-      const die = new StandardDice('4d6', 6, 4);
+      const die = new StandardDice(6, 4);
 
       expect(() => {
         die.qty = 6;
@@ -615,7 +623,7 @@ describe('StandardDice', () => {
     });
 
     test('cannot change sides value', () => {
-      const die = new StandardDice('4d6', 6, 4);
+      const die = new StandardDice(6, 4);
 
       expect(() => {
         die.sides = 2;

--- a/tests/modifiers/ComparisonModifier.test.js
+++ b/tests/modifiers/ComparisonModifier.test.js
@@ -2,56 +2,38 @@ import ComparisonModifier from '../../src/modifiers/ComparisonModifier';
 import ComparePoint from '../../src/ComparePoint';
 import StandardDice from '../../src/dice/StandardDice';
 import RollResults from '../../src/results/RollResults';
-import RequiredArgumentError from '../../src/exceptions/RequiredArgumentError';
 
 describe('ComparisonModifier', () => {
   describe('Initialisation', () => {
     test('model structure', () => {
-      const mod = new ComparisonModifier('>8');
+      const mod = new ComparisonModifier();
 
       expect(mod).toBeInstanceOf(ComparisonModifier);
       expect(mod).toEqual(expect.objectContaining({
         comparePoint: undefined,
         isComparePoint: expect.any(Function),
         name: 'comparison',
-        notation: '>8',
+        notation: '',
         toJSON: expect.any(Function),
         toString: expect.any(Function),
       }));
-    });
-
-    test('constructor requires notation', () => {
-      expect(() => {
-        new ComparisonModifier();
-      }).toThrow(RequiredArgumentError);
-
-      expect(() => {
-        new ComparisonModifier(false);
-      }).toThrow(RequiredArgumentError);
-
-      expect(() => {
-        new ComparisonModifier(null);
-      }).toThrow(RequiredArgumentError);
-
-      expect(() => {
-        new ComparisonModifier(undefined);
-      }).toThrow(RequiredArgumentError);
     });
   });
 
   describe('Compare point', () => {
     test('gets set in constructor', () => {
       const cp = new ComparePoint('>', 8);
-      const mod = new ComparisonModifier('>8', cp);
+      const mod = new ComparisonModifier(cp);
 
       expect(mod.comparePoint).toBe(cp);
+      expect(mod.notation).toEqual('>8');
     });
 
     test('setting in constructor calls setter', () => {
       const spy = jest.spyOn(ComparisonModifier.prototype, 'comparePoint', 'set');
 
       // create the ComparisonModifier
-      new ComparisonModifier('>8', new ComparePoint('>', 8));
+      new ComparisonModifier(new ComparePoint('>', 8));
 
       expect(spy).toHaveBeenCalledTimes(1);
 
@@ -60,7 +42,7 @@ describe('ComparisonModifier', () => {
     });
 
     test('must be instance of ComparePoint', () => {
-      const mod = new ComparisonModifier('>8');
+      const mod = new ComparisonModifier();
 
       expect(() => {
         mod.comparePoint = 'foo';
@@ -92,7 +74,7 @@ describe('ComparisonModifier', () => {
     });
 
     test('cannot unset compare point', () => {
-      const mod = new ComparisonModifier('>8');
+      const mod = new ComparisonModifier();
 
       expect(() => {
         mod.comparePoint = null;
@@ -107,7 +89,7 @@ describe('ComparisonModifier', () => {
   describe('Matching', () => {
     test('can match against values', () => {
       const spy = jest.spyOn(ComparePoint.prototype, 'isMatch');
-      const mod = new ComparisonModifier('>8', new ComparePoint('>', 8));
+      const mod = new ComparisonModifier(new ComparePoint('>', 8));
 
       // attempt to match
       expect(mod.isComparePoint(9)).toBe(true);
@@ -122,15 +104,28 @@ describe('ComparisonModifier', () => {
     });
 
     test('with no ComparePoint return false', () => {
-      const mod = new ComparisonModifier('>8');
+      const mod = new ComparisonModifier();
 
       expect(mod.isComparePoint(9)).toBe(false);
     });
   });
 
+  describe('Notation', () => {
+    test('simple notation', () => {
+      let mod = new ComparisonModifier(new ComparePoint('=', 45));
+      expect(mod.notation).toEqual('=45');
+
+      mod = new ComparisonModifier(new ComparePoint('!=', 4.78));
+      expect(mod.notation).toEqual('!=4.78');
+
+      mod = new ComparisonModifier(new ComparePoint('<=', 568));
+      expect(mod.notation).toEqual('<=568');
+    });
+  });
+
   describe('Output', () => {
     test('JSON output is correct', () => {
-      const mod = new ComparisonModifier('=4', new ComparePoint('=', 4));
+      const mod = new ComparisonModifier(new ComparePoint('=', 4));
 
       // json encode, to get the encoded string, then decode so we can compare the object
       // this allows us to check that the output is correct, but ignoring the order of the
@@ -148,7 +143,7 @@ describe('ComparisonModifier', () => {
     });
 
     test('toString output is correct', () => {
-      const mod = new ComparisonModifier('=4', new ComparePoint('=', 4));
+      const mod = new ComparisonModifier(new ComparePoint('=', 4));
 
       expect(mod.toString()).toEqual('=4');
     });
@@ -157,8 +152,8 @@ describe('ComparisonModifier', () => {
   describe('Run', () => {
     test('returns RollResults object', () => {
       const results = new RollResults();
-      const die = new StandardDice('2d6', 6, 2);
-      const mod = new ComparisonModifier('=4', new ComparePoint('=', 4));
+      const die = new StandardDice(6, 2);
+      const mod = new ComparisonModifier(new ComparePoint('=', 4));
 
       expect(mod.run(results, die)).toBe(results);
     });
@@ -166,7 +161,7 @@ describe('ComparisonModifier', () => {
 
   describe('Readonly properties', () => {
     test('cannot change name value', () => {
-      const mod = new ComparisonModifier('=4');
+      const mod = new ComparisonModifier();
 
       expect(() => {
         mod.name = 'Foo';

--- a/tests/modifiers/ExplodeModifier.test.js
+++ b/tests/modifiers/ExplodeModifier.test.js
@@ -1,16 +1,14 @@
+import { StandardDice } from '../../src/Dice';
+import { ComparisonModifier, ExplodeModifier } from '../../src/Modifiers';
 import ComparePoint from '../../src/ComparePoint';
-import ComparisonModifier from '../../src/modifiers/ComparisonModifier';
 import DieActionValueError from '../../src/exceptions/DieActionValueError';
-import ExplodeModifier from '../../src/modifiers/ExplodeModifier';
-import RequiredArgumentError from '../../src/exceptions/RequiredArgumentError';
 import RollResult from '../../src/results/RollResult';
 import RollResults from '../../src/results/RollResults';
-import StandardDice from '../../src/dice/StandardDice';
 
 describe('ExplodeModifier', () => {
   describe('Initialisation', () => {
     test('model structure', () => {
-      const mod = new ExplodeModifier('!');
+      const mod = new ExplodeModifier();
 
       expect(mod).toBeInstanceOf(ExplodeModifier);
       expect(mod).toBeInstanceOf(ComparisonModifier);
@@ -27,39 +25,22 @@ describe('ExplodeModifier', () => {
         toString: expect.any(Function),
       }));
     });
-
-    test('constructor requires notation', () => {
-      expect(() => {
-        new ExplodeModifier();
-      }).toThrow(RequiredArgumentError);
-
-      expect(() => {
-        new ExplodeModifier(false);
-      }).toThrow(RequiredArgumentError);
-
-      expect(() => {
-        new ExplodeModifier(null);
-      }).toThrow(RequiredArgumentError);
-
-      expect(() => {
-        new ExplodeModifier(undefined);
-      }).toThrow(RequiredArgumentError);
-    });
   });
 
   describe('Compare Point', () => {
     test('gets set in constructor', () => {
-      const cp = new ComparePoint('>', 8);
-      const mod = new ExplodeModifier('!>8', cp);
+      const cp = new ComparePoint('=', 12);
+      const mod = new ExplodeModifier(cp);
 
       expect(mod.comparePoint).toBe(cp);
+      expect(mod.notation).toBe('!=12');
     });
 
     test('setting in constructor calls setter in parent', () => {
       const spy = jest.spyOn(ComparisonModifier.prototype, 'comparePoint', 'set');
 
       // create the ComparisonModifier
-      new ExplodeModifier('!>8', new ComparePoint('>', 8));
+      new ExplodeModifier(new ComparePoint('>', 8));
 
       expect(spy).toHaveBeenCalledTimes(1);
 
@@ -71,7 +52,7 @@ describe('ExplodeModifier', () => {
   describe('Matching', () => {
     test('isComparePoint uses parent', () => {
       const spy = jest.spyOn(ComparisonModifier.prototype, 'isComparePoint');
-      const mod = new ExplodeModifier('!>8', new ComparePoint('>', 8));
+      const mod = new ExplodeModifier(new ComparePoint('>', 8));
 
       // attempt to match
       expect(mod.isComparePoint(9)).toBe(true);
@@ -88,50 +69,98 @@ describe('ExplodeModifier', () => {
 
   describe('Compound', () => {
     test('gets set in constructor', () => {
-      const mod = new ExplodeModifier('!>8', null, true);
+      const mod = new ExplodeModifier(null, true);
 
       expect(mod.compound).toBe(true);
+      expect(mod.notation).toBe('!!');
     });
 
     test('cast to boolean', () => {
-      expect((new ExplodeModifier('!>8', null, false)).compound).toBe(false);
-      expect((new ExplodeModifier('!>8', null, 'foo')).compound).toBe(true);
-      expect((new ExplodeModifier('!>8', null, '')).compound).toBe(false);
-      expect((new ExplodeModifier('!>8', null, '0')).compound).toBe(true);
-      expect((new ExplodeModifier('!>8', null, 0)).compound).toBe(false);
-      expect((new ExplodeModifier('!>8', null, 1)).compound).toBe(true);
-      expect((new ExplodeModifier('!>8', null, [])).compound).toBe(true);
-      expect((new ExplodeModifier('!>8', null, {})).compound).toBe(true);
-      expect((new ExplodeModifier('!>8', null, null)).compound).toBe(false);
-      expect((new ExplodeModifier('!>8', null, undefined)).compound).toBe(false);
+      expect((new ExplodeModifier(null, false)).compound).toBe(false);
+      expect((new ExplodeModifier(null, 'foo')).compound).toBe(true);
+      expect((new ExplodeModifier(null, '')).compound).toBe(false);
+      expect((new ExplodeModifier(null, '0')).compound).toBe(true);
+      expect((new ExplodeModifier(null, 0)).compound).toBe(false);
+      expect((new ExplodeModifier(null, 1)).compound).toBe(true);
+      expect((new ExplodeModifier(null, [])).compound).toBe(true);
+      expect((new ExplodeModifier(null, {})).compound).toBe(true);
+      expect((new ExplodeModifier(null, null)).compound).toBe(false);
+      expect((new ExplodeModifier(null, undefined)).compound).toBe(false);
     });
   });
 
   describe('Penetrate', () => {
     test('gets set in constructor', () => {
-      const mod = new ExplodeModifier('!>8', null, null, true);
+      const mod = new ExplodeModifier(null, null, true);
 
       expect(mod.penetrate).toBe(true);
+      expect(mod.notation).toBe('!p');
     });
 
     test('cast to boolean', () => {
-      expect((new ExplodeModifier('!>8', null, null, false)).penetrate).toBe(false);
-      expect((new ExplodeModifier('!>8', null, null, 'foo')).penetrate).toBe(true);
-      expect((new ExplodeModifier('!>8', null, null, '')).penetrate).toBe(false);
-      expect((new ExplodeModifier('!>8', null, null, '0')).penetrate).toBe(true);
-      expect((new ExplodeModifier('!>8', null, null, 0)).penetrate).toBe(false);
-      expect((new ExplodeModifier('!>8', null, null, 1)).penetrate).toBe(true);
-      expect((new ExplodeModifier('!>8', null, null, [])).penetrate).toBe(true);
-      expect((new ExplodeModifier('!>8', null, null, {})).penetrate).toBe(true);
-      expect((new ExplodeModifier('!>8', null, null, null)).penetrate).toBe(false);
-      expect((new ExplodeModifier('!>8', null, null, undefined)).penetrate).toBe(false);
+      expect((new ExplodeModifier(null, null, false)).penetrate).toBe(false);
+      expect((new ExplodeModifier(null, null, 'foo')).penetrate).toBe(true);
+      expect((new ExplodeModifier(null, null, '')).penetrate).toBe(false);
+      expect((new ExplodeModifier(null, null, '0')).penetrate).toBe(true);
+      expect((new ExplodeModifier(null, null, 0)).penetrate).toBe(false);
+      expect((new ExplodeModifier(null, null, 1)).penetrate).toBe(true);
+      expect((new ExplodeModifier(null, null, [])).penetrate).toBe(true);
+      expect((new ExplodeModifier(null, null, {})).penetrate).toBe(true);
+      expect((new ExplodeModifier(null, null, null)).penetrate).toBe(false);
+      expect((new ExplodeModifier(null, null, undefined)).penetrate).toBe(false);
+    });
+  });
+
+  describe('Notation', () => {
+    test('explode', () => {
+      let mod = new ExplodeModifier(new ComparePoint('>=', 45));
+      expect(mod.notation).toEqual('!>=45');
+
+      mod = new ExplodeModifier(new ComparePoint('<', 1));
+      expect(mod.notation).toEqual('!<1');
+
+      mod = new ExplodeModifier(new ComparePoint('<=', 678997595));
+      expect(mod.notation).toEqual('!<=678997595');
+    });
+
+    test('compound', () => {
+      let mod = new ExplodeModifier(new ComparePoint('>=', 16), true);
+      expect(mod.notation).toEqual('!!>=16');
+
+      mod = new ExplodeModifier(new ComparePoint('<', 79), true);
+      expect(mod.notation).toEqual('!!<79');
+
+      mod = new ExplodeModifier(new ComparePoint('<=', 678997595), true);
+      expect(mod.notation).toEqual('!!<=678997595');
+    });
+
+    test('penetrate', () => {
+      let mod = new ExplodeModifier(new ComparePoint('>=', 16), false, true);
+      expect(mod.notation).toEqual('!p>=16');
+
+      mod = new ExplodeModifier(new ComparePoint('<', 79), false, true);
+      expect(mod.notation).toEqual('!p<79');
+
+      mod = new ExplodeModifier(new ComparePoint('<=', 678997595), false, true);
+      expect(mod.notation).toEqual('!p<=678997595');
+    });
+
+    test('compound and penetrate', () => {
+      let mod = new ExplodeModifier(new ComparePoint('>=', 16), true, true);
+      expect(mod.notation).toEqual('!!p>=16');
+
+      mod = new ExplodeModifier(new ComparePoint('<', 79), true, true);
+      expect(mod.notation).toEqual('!!p<79');
+
+      mod = new ExplodeModifier(new ComparePoint('<=', 678997595), true, true);
+      expect(mod.notation).toEqual('!!p<=678997595');
     });
   });
 
   describe('Output', () => {
     test('JSON output is correct', () => {
       const cp = new ComparePoint('<=', 3);
-      const mod = new ExplodeModifier('!!p<=3', cp, true, true);
+      const mod = new ExplodeModifier(cp, true, true);
 
       // json encode, to get the encoded string, then decode so we can compare the object
       // this allows us to check that the output is correct, but ignoring the order of the
@@ -147,7 +176,8 @@ describe('ExplodeModifier', () => {
     });
 
     test('toString output is correct', () => {
-      const mod = new ExplodeModifier('!>5');
+      const cp = new ComparePoint('>', 5);
+      const mod = new ExplodeModifier(cp);
 
       expect(mod.toString()).toEqual('!>5');
     });
@@ -162,8 +192,8 @@ describe('ExplodeModifier', () => {
       results = new RollResults([
         8, 4, 2, 1, 6, 10,
       ]);
-      die = new StandardDice('6d10', 10, 6);
-      mod = new ExplodeModifier('!');
+      die = new StandardDice(10, 6);
+      mod = new ExplodeModifier();
 
       jest.spyOn(StandardDice.prototype, 'rollOnce')
         .mockImplementationOnce(() => new RollResult(10))
@@ -353,7 +383,7 @@ describe('ExplodeModifier', () => {
     });
 
     test('can compound with compare point `>5`', () => {
-      mod = new ExplodeModifier('!!', new ComparePoint('>', 5), true);
+      mod = new ExplodeModifier(new ComparePoint('>', 5), true);
 
       const { rolls } = mod.run(results, die);
 
@@ -392,7 +422,7 @@ describe('ExplodeModifier', () => {
     });
 
     test('can penetrate with compare point `<=4`', () => {
-      mod = new ExplodeModifier('!p', new ComparePoint('<=', 4), false, true);
+      mod = new ExplodeModifier(new ComparePoint('<=', 4), false, true);
 
       const { rolls } = mod.run(results, die);
 
@@ -463,7 +493,7 @@ describe('ExplodeModifier', () => {
     });
 
     test('can compound and penetrate with compare point >6', () => {
-      mod = new ExplodeModifier('!!p', new ComparePoint('>', 6), true, true);
+      mod = new ExplodeModifier(new ComparePoint('>', 6), true, true);
 
       const { rolls } = mod.run(results, die);
 
@@ -503,7 +533,7 @@ describe('ExplodeModifier', () => {
 
     test('exploding with d1 throws an error', () => {
       // create a 1 sided die
-      die = new StandardDice('6d1', 1, 6);
+      die = new StandardDice(1, 6);
 
       // set the modifier compare point
       mod.comparePoint = new ComparePoint('>=', 8);
@@ -527,7 +557,7 @@ describe('ExplodeModifier', () => {
           results = new RollResults(Array(qty).fill(1));
 
           // create the dice
-          die = new StandardDice(`${qty}d10`, 10, qty);
+          die = new StandardDice(10, qty);
 
           // apply modifiers
           const { rolls } = mod.run(results, die);
@@ -541,7 +571,7 @@ describe('ExplodeModifier', () => {
 
   describe('Readonly properties', () => {
     test('cannot change name value', () => {
-      const mod = new ExplodeModifier('!');
+      const mod = new ExplodeModifier();
 
       expect(() => {
         mod.name = 'Foo';
@@ -549,7 +579,7 @@ describe('ExplodeModifier', () => {
     });
 
     test('cannot change compound value', () => {
-      const mod = new ExplodeModifier('!');
+      const mod = new ExplodeModifier();
 
       expect(() => {
         mod.compound = true;
@@ -557,7 +587,7 @@ describe('ExplodeModifier', () => {
     });
 
     test('cannot change penetrate value', () => {
-      const mod = new ExplodeModifier('!');
+      const mod = new ExplodeModifier();
 
       expect(() => {
         mod.penetrate = true;

--- a/tests/modifiers/MaxModifier.test.js
+++ b/tests/modifiers/MaxModifier.test.js
@@ -1,6 +1,5 @@
-import MaxModifier from '../../src/modifiers/MaxModifier';
+import { MaxModifier } from '../../src/Modifiers';
 import Modifier from '../../src/modifiers/Modifier';
-import RequiredArgumentError from '../../src/exceptions/RequiredArgumentError';
 import StandardDice from '../../src/dice/StandardDice';
 import RollResults from '../../src/results/RollResults';
 
@@ -8,7 +7,7 @@ describe('MaxModifier', () => {
   let mod;
 
   beforeEach(() => {
-    mod = new MaxModifier('max3', 3);
+    mod = new MaxModifier(3);
   });
 
   describe('Initialisation', () => {
@@ -26,39 +25,21 @@ describe('MaxModifier', () => {
       }));
     });
 
-    test('constructor requires notation', () => {
+    test('constructor requires max', () => {
       expect(() => {
         new MaxModifier();
-      }).toThrow(RequiredArgumentError);
+      }).toThrow(TypeError);
 
       expect(() => {
         new MaxModifier(false);
-      }).toThrow(RequiredArgumentError);
+      }).toThrow(TypeError);
 
       expect(() => {
         new MaxModifier(null);
-      }).toThrow(RequiredArgumentError);
+      }).toThrow(TypeError);
 
       expect(() => {
         new MaxModifier(undefined);
-      }).toThrow(RequiredArgumentError);
-    });
-
-    test('constructor requires max', () => {
-      expect(() => {
-        new MaxModifier('max3');
-      }).toThrow(TypeError);
-
-      expect(() => {
-        new MaxModifier('max3', false);
-      }).toThrow(TypeError);
-
-      expect(() => {
-        new MaxModifier('max3', null);
-      }).toThrow(TypeError);
-
-      expect(() => {
-        new MaxModifier('max3', undefined);
       }).toThrow(TypeError);
     });
   });
@@ -66,12 +47,15 @@ describe('MaxModifier', () => {
   describe('Max', () => {
     test('can be changed', () => {
       expect(mod.max).toBe(3);
+      expect(mod.notation).toBe('max3');
 
       mod.max = 1;
       expect(mod.max).toBe(1);
+      expect(mod.notation).toBe('max1');
 
       mod.max = 23;
       expect(mod.max).toBe(23);
+      expect(mod.notation).toBe('max23');
     });
 
     test('must be numeric', () => {
@@ -91,17 +75,37 @@ describe('MaxModifier', () => {
     test('can be float', () => {
       mod.max = 4.5;
       expect(mod.max).toBeCloseTo(4.5);
+      expect(mod.notation).toBe('max4.5');
 
       mod.max = 300.6579;
       expect(mod.max).toBeCloseTo(300.6579);
+      expect(mod.notation).toBe('max300.6579');
     });
 
     test('can be negative', () => {
       mod.max = -10;
       expect(mod.max).toBe(-10);
+      expect(mod.notation).toBe('max-10');
 
       mod.max = -46.2;
       expect(mod.max).toBeCloseTo(-46.2);
+      expect(mod.notation).toBe('max-46.2');
+    });
+  });
+
+  describe('Notation', () => {
+    test('simple notation', () => {
+      mod = new MaxModifier(35);
+      expect(mod.notation).toEqual('max35');
+
+      mod = new MaxModifier(90876684);
+      expect(mod.notation).toEqual('max90876684');
+
+      mod = new MaxModifier(7986);
+      expect(mod.notation).toEqual('max7986');
+
+      mod = new MaxModifier(2);
+      expect(mod.notation).toEqual('max2');
     });
   });
 
@@ -128,7 +132,7 @@ describe('MaxModifier', () => {
       results = new RollResults([
         1, 4, 2, 1, 6,
       ]);
-      die = new StandardDice('5d10', 10, 5);
+      die = new StandardDice(10, 5);
     });
 
     test('returns RollResults object', () => {

--- a/tests/modifiers/MinModifier.test.js
+++ b/tests/modifiers/MinModifier.test.js
@@ -1,6 +1,5 @@
-import MinModifier from '../../src/modifiers/MinModifier';
+import { MinModifier } from '../../src/Modifiers';
 import Modifier from '../../src/modifiers/Modifier';
-import RequiredArgumentError from '../../src/exceptions/RequiredArgumentError';
 import StandardDice from '../../src/dice/StandardDice';
 import RollResults from '../../src/results/RollResults';
 
@@ -8,7 +7,7 @@ describe('MinModifier', () => {
   let mod;
 
   beforeEach(() => {
-    mod = new MinModifier('min3', 3);
+    mod = new MinModifier(3);
   });
 
   describe('Initialisation', () => {
@@ -26,39 +25,21 @@ describe('MinModifier', () => {
       }));
     });
 
-    test('constructor requires notation', () => {
+    test('constructor requires min', () => {
       expect(() => {
         new MinModifier();
-      }).toThrow(RequiredArgumentError);
+      }).toThrow(TypeError);
 
       expect(() => {
         new MinModifier(false);
-      }).toThrow(RequiredArgumentError);
+      }).toThrow(TypeError);
 
       expect(() => {
         new MinModifier(null);
-      }).toThrow(RequiredArgumentError);
+      }).toThrow(TypeError);
 
       expect(() => {
         new MinModifier(undefined);
-      }).toThrow(RequiredArgumentError);
-    });
-
-    test('constructor requires min', () => {
-      expect(() => {
-        new MinModifier('min3');
-      }).toThrow(TypeError);
-
-      expect(() => {
-        new MinModifier('min3', false);
-      }).toThrow(TypeError);
-
-      expect(() => {
-        new MinModifier('min3', null);
-      }).toThrow(TypeError);
-
-      expect(() => {
-        new MinModifier('min3', undefined);
       }).toThrow(TypeError);
     });
   });
@@ -66,12 +47,15 @@ describe('MinModifier', () => {
   describe('Min', () => {
     test('can be changed', () => {
       expect(mod.min).toBe(3);
+      expect(mod.notation).toBe('min3');
 
       mod.min = 1;
       expect(mod.min).toBe(1);
+      expect(mod.notation).toBe('min1');
 
       mod.min = 23;
       expect(mod.min).toBe(23);
+      expect(mod.notation).toBe('min23');
     });
 
     test('must be numeric', () => {
@@ -91,17 +75,37 @@ describe('MinModifier', () => {
     test('can be float', () => {
       mod.min = 4.5;
       expect(mod.min).toBeCloseTo(4.5);
+      expect(mod.notation).toBe('min4.5');
 
       mod.min = 300.6579;
       expect(mod.min).toBeCloseTo(300.6579);
+      expect(mod.notation).toBe('min300.6579');
     });
 
     test('can be negative', () => {
       mod.min = -10;
       expect(mod.min).toBe(-10);
+      expect(mod.notation).toBe('min-10');
 
       mod.min = -46.2;
       expect(mod.min).toBeCloseTo(-46.2);
+      expect(mod.notation).toBe('min-46.2');
+    });
+  });
+
+  describe('Notation', () => {
+    test('simple notation', () => {
+      mod = new MinModifier(35);
+      expect(mod.notation).toEqual('min35');
+
+      mod = new MinModifier(90876684);
+      expect(mod.notation).toEqual('min90876684');
+
+      mod = new MinModifier(7986);
+      expect(mod.notation).toEqual('min7986');
+
+      mod = new MinModifier(2);
+      expect(mod.notation).toEqual('min2');
     });
   });
 
@@ -128,7 +132,7 @@ describe('MinModifier', () => {
       results = new RollResults([
         1, 4, 2, 1, 6,
       ]);
-      die = new StandardDice('5d10', 10, 5);
+      die = new StandardDice(10, 5);
     });
 
     test('returns RollResults object', () => {

--- a/tests/modifiers/Modifier.test.js
+++ b/tests/modifiers/Modifier.test.js
@@ -1,0 +1,60 @@
+import Modifier from '../../src/modifiers/Modifier';
+import RollResults from '../../src/results/RollResults';
+import { StandardDice } from '../../src/Dice';
+
+describe('Modifier', () => {
+  describe('Initialisation', () => {
+    test('model structure', () => {
+      const mod = new Modifier();
+
+      expect(mod).toBeInstanceOf(Modifier);
+      expect(mod).toEqual(expect.objectContaining({
+        maxIterations: 1000,
+        name: 'modifier',
+        notation: '',
+        run: expect.any(Function),
+        toJSON: expect.any(Function),
+        toString: expect.any(Function),
+      }));
+    });
+  });
+
+  describe('Output', () => {
+    test('JSON output is correct', () => {
+      const mod = new Modifier();
+
+      // json encode, to get the encoded string, then decode so we can compare the object
+      // this allows us to check that the output is correct, but ignoring the order of the
+      // returned properties
+      expect(JSON.parse(JSON.stringify(mod))).toEqual({
+        name: 'modifier',
+        notation: '',
+        type: 'modifier',
+      });
+    });
+
+    test('toString output is correct', () => {
+      const mod = new Modifier();
+
+      expect(mod.toString()).toEqual('');
+    });
+  });
+
+  describe('Run', () => {
+    let mod;
+    let die;
+    let results;
+
+    beforeEach(() => {
+      results = new RollResults([
+        8, 4, 2, 1, 6, 10,
+      ]);
+      die = new StandardDice(10, 6);
+      mod = new Modifier();
+    });
+
+    test('returns RollResults object', () => {
+      expect(mod.run(results, die)).toBe(results);
+    });
+  });
+});

--- a/tests/modifiers/SortingModifier.test.js
+++ b/tests/modifiers/SortingModifier.test.js
@@ -1,64 +1,48 @@
-import SortingModifier from '../../src/modifiers/SortingModifier';
+import { StandardDice } from '../../src/Dice';
+import { SortingModifier } from '../../src/Modifiers';
 import Modifier from '../../src/modifiers/Modifier';
 import RollResults from '../../src/results/RollResults';
-import StandardDice from '../../src/dice/StandardDice';
-import RequiredArgumentError from '../../src/exceptions/RequiredArgumentError';
 
 describe('SortingModifier', () => {
   describe('Initialisation', () => {
     test('model structure', () => {
-      const mod = new SortingModifier('s');
+      const mod = new SortingModifier();
 
       expect(mod).toBeInstanceOf(SortingModifier);
       expect(mod).toBeInstanceOf(Modifier);
       expect(mod).toEqual(expect.objectContaining({
         direction: 'a',
         name: 'sorting',
-        notation: 's',
+        notation: 'sa',
         run: expect.any(Function),
         toJSON: expect.any(Function),
         toString: expect.any(Function),
       }));
     });
-
-    test('constructor requires notation', () => {
-      expect(() => {
-        new SortingModifier();
-      }).toThrow(RequiredArgumentError);
-
-      expect(() => {
-        new SortingModifier(false);
-      }).toThrow(RequiredArgumentError);
-
-      expect(() => {
-        new SortingModifier(null);
-      }).toThrow(RequiredArgumentError);
-
-      expect(() => {
-        new SortingModifier(undefined);
-      }).toThrow(RequiredArgumentError);
-    });
   });
 
   describe('Direction', () => {
     test('gets set in constructor', () => {
-      const mod = new SortingModifier('sd', 'd');
+      const mod = new SortingModifier('d');
 
       expect(mod.direction).toEqual('d');
+      expect(mod.notation).toBe('sd');
     });
 
     test('can be changed', () => {
-      const mod = new SortingModifier('sa', 'a');
+      const mod = new SortingModifier('a');
 
       expect(mod.direction).toEqual('a');
+      expect(mod.notation).toBe('sa');
 
       mod.direction = 'd';
 
       expect(mod.direction).toEqual('d');
+      expect(mod.notation).toBe('sd');
     });
 
-    test('throws error if not set to `a` | `b`', () => {
-      const mod = new SortingModifier('s');
+    test('throws error if not set to `a` | `d`', () => {
+      const mod = new SortingModifier();
 
       expect(() => {
         mod.direction = 'foo';
@@ -94,9 +78,24 @@ describe('SortingModifier', () => {
     });
   });
 
+  describe('Notation', () => {
+    test('ascending', () => {
+      let mod = new SortingModifier();
+      expect(mod.notation).toEqual('sa');
+
+      mod = new SortingModifier('a');
+      expect(mod.notation).toEqual('sa');
+    });
+
+    test('descending', () => {
+      const mod = new SortingModifier('d');
+      expect(mod.notation).toEqual('sd');
+    });
+  });
+
   describe('Output', () => {
     test('JSON output is correct', () => {
-      const mod = new SortingModifier('sd', 'd');
+      const mod = new SortingModifier('d');
 
       // json encode, to get the encoded string, then decode so we can compare the object
       // this allows us to check that the output is correct, but ignoring the order of the
@@ -110,22 +109,23 @@ describe('SortingModifier', () => {
     });
 
     test('toString output is correct', () => {
-      const mod = new SortingModifier('sa');
+      const mod = new SortingModifier();
 
       expect(mod.toString()).toEqual('sa');
     });
   });
 
   describe('Run', () => {
-    let mod; let die; let
-      results;
+    let mod;
+    let die;
+    let results;
 
     beforeEach(() => {
       results = new RollResults([
         8, 4, 2, 1, 6, 10,
       ]);
-      die = new StandardDice('6d10', 10, 6);
-      mod = new SortingModifier('a');
+      die = new StandardDice(10, 6);
+      mod = new SortingModifier();
     });
 
     test('returns RollResults object', () => {

--- a/tests/parser/Parser.test.js
+++ b/tests/parser/Parser.test.js
@@ -1,17 +1,19 @@
 import { FudgeDice, PercentileDice, StandardDice } from '../../src/Dice';
-import CriticalFailureModifier from '../../src/modifiers/CriticalFailureModifier';
-import CriticalSuccessModifier from '../../src/modifiers/CriticalSuccessModifier';
-import DropModifier from '../../src/modifiers/DropModifier';
-import ExplodeModifier from '../../src/modifiers/ExplodeModifier';
-import KeepModifier from '../../src/modifiers/KeepModifier';
-import MaxModifier from '../../src/modifiers/MaxModifier';
-import MinModifier from '../../src/modifiers/MinModifier';
+import {
+  CriticalFailureModifier,
+  CriticalSuccessModifier,
+  DropModifier,
+  ExplodeModifier,
+  KeepModifier,
+  MaxModifier,
+  MinModifier,
+  ReRollModifier,
+  SortingModifier,
+  TargetModifier,
+} from '../../src/Modifiers';
 import * as parser from '../../src/parser/grammars/grammar';
 import Parser from '../../src/parser/Parser';
-import SortingModifier from '../../src/modifiers/SortingModifier';
-import TargetModifier from '../../src/modifiers/TargetModifier';
 import RequiredArgumentError from '../../src/exceptions/RequiredArgumentError';
-import ReRollModifier from '../../src/modifiers/ReRollModifier';
 
 describe('Parser', () => {
   describe('Initialisation', () => {
@@ -68,12 +70,9 @@ describe('Parser', () => {
         expect(parsed).toBeInstanceOf(Array);
         expect(parsed).toHaveLength(1);
         expect(parsed[0]).toBeInstanceOf(StandardDice);
-        expect(parsed[0]).toEqual(expect.objectContaining({
-          modifiers: new Map(),
-          notation: 'd6',
-          sides: 6,
-          qty: 1,
-        }));
+        expect(parsed[0].sides).toBe(6);
+        expect(parsed[0].qty).toBe(1);
+        expect(parsed[0].modifiers).toEqual(new Map());
       });
 
       test('returns correct response for `5d10`', () => {
@@ -82,12 +81,9 @@ describe('Parser', () => {
         expect(parsed).toBeInstanceOf(Array);
         expect(parsed).toHaveLength(1);
         expect(parsed[0]).toBeInstanceOf(StandardDice);
-        expect(parsed[0]).toEqual(expect.objectContaining({
-          modifiers: new Map(),
-          notation: '5d10',
-          sides: 10,
-          qty: 5,
-        }));
+        expect(parsed[0].sides).toBe(10);
+        expect(parsed[0].qty).toBe(5);
+        expect(parsed[0].modifiers).toEqual(new Map());
       });
 
       test('returns correct response for `4d20`', () => {
@@ -96,12 +92,9 @@ describe('Parser', () => {
         expect(parsed).toBeInstanceOf(Array);
         expect(parsed).toHaveLength(1);
         expect(parsed[0]).toBeInstanceOf(StandardDice);
-        expect(parsed[0]).toEqual(expect.objectContaining({
-          modifiers: new Map(),
-          notation: '4d20',
-          sides: 20,
-          qty: 4,
-        }));
+        expect(parsed[0].sides).toBe(20);
+        expect(parsed[0].qty).toBe(4);
+        expect(parsed[0].modifiers).toEqual(new Map());
       });
 
       test('returns correct response for `2d%`', () => {
@@ -110,12 +103,9 @@ describe('Parser', () => {
         expect(parsed).toBeInstanceOf(Array);
         expect(parsed).toHaveLength(1);
         expect(parsed[0]).toBeInstanceOf(PercentileDice);
-        expect(parsed[0]).toEqual(expect.objectContaining({
-          modifiers: new Map(),
-          notation: '2d%',
-          sides: '%',
-          qty: 2,
-        }));
+        expect(parsed[0].sides).toBe('%');
+        expect(parsed[0].qty).toBe(2);
+        expect(parsed[0].modifiers).toEqual(new Map());
       });
 
       test('returns correct response for `4dF`', () => {
@@ -124,12 +114,9 @@ describe('Parser', () => {
         expect(parsed).toBeInstanceOf(Array);
         expect(parsed).toHaveLength(1);
         expect(parsed[0]).toBeInstanceOf(FudgeDice);
-        expect(parsed[0]).toEqual(expect.objectContaining({
-          modifiers: new Map(),
-          notation: '4dF',
-          sides: 'F.2',
-          qty: 4,
-        }));
+        expect(parsed[0].sides).toBe('F.2');
+        expect(parsed[0].qty).toBe(4);
+        expect(parsed[0].modifiers).toEqual(new Map());
       });
 
       test('returns correct response for `dF.2`', () => {
@@ -138,12 +125,9 @@ describe('Parser', () => {
         expect(parsed).toBeInstanceOf(Array);
         expect(parsed).toHaveLength(1);
         expect(parsed[0]).toBeInstanceOf(FudgeDice);
-        expect(parsed[0]).toEqual(expect.objectContaining({
-          modifiers: new Map(),
-          notation: 'dF.2',
-          sides: 'F.2',
-          qty: 1,
-        }));
+        expect(parsed[0].sides).toBe('F.2');
+        expect(parsed[0].qty).toBe(1);
+        expect(parsed[0].modifiers).toEqual(new Map());
       });
 
       test('returns correct response for `10dF.1`', () => {
@@ -152,12 +136,9 @@ describe('Parser', () => {
         expect(parsed).toBeInstanceOf(Array);
         expect(parsed).toHaveLength(1);
         expect(parsed[0]).toBeInstanceOf(FudgeDice);
-        expect(parsed[0]).toEqual(expect.objectContaining({
-          modifiers: new Map(),
-          notation: '10dF.1',
-          sides: 'F.1',
-          qty: 10,
-        }));
+        expect(parsed[0].sides).toBe('F.1');
+        expect(parsed[0].qty).toBe(10);
+        expect(parsed[0].modifiers).toEqual(new Map());
       });
 
       test('throws error for invalid Fudge die sides', () => {
@@ -212,7 +193,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('1d8');
           expect(parsed[0].sides).toEqual(8);
           expect(parsed[0].qty).toEqual(1);
 
@@ -221,7 +201,6 @@ describe('Parser', () => {
           const mod = parsed[0].modifiers.get('critical-failure');
           expect(mod).toBeInstanceOf(CriticalFailureModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: 'cf<4',
             comparePoint: expect.objectContaining({
               operator: '<',
               value: 4,
@@ -236,7 +215,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(FudgeDice);
 
-          expect(parsed[0].notation).toEqual('3dF.1');
           expect(parsed[0].sides).toEqual('F.1');
           expect(parsed[0].qty).toEqual(3);
 
@@ -245,7 +223,6 @@ describe('Parser', () => {
           const mod = parsed[0].modifiers.get('critical-failure');
           expect(mod).toBeInstanceOf(CriticalFailureModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: 'cf>8',
             comparePoint: expect.objectContaining({
               operator: '>',
               value: 8,
@@ -268,7 +245,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('8d45');
           expect(parsed[0].sides).toEqual(45);
           expect(parsed[0].qty).toEqual(8);
 
@@ -277,7 +253,6 @@ describe('Parser', () => {
           const mod = parsed[0].modifiers.get('critical-success');
           expect(mod).toBeInstanceOf(CriticalSuccessModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: 'cs=12',
             comparePoint: expect.objectContaining({
               operator: '=',
               value: 12,
@@ -292,7 +267,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('36d152');
           expect(parsed[0].sides).toEqual(152);
           expect(parsed[0].qty).toEqual(36);
 
@@ -301,7 +275,6 @@ describe('Parser', () => {
           const mod = parsed[0].modifiers.get('critical-success');
           expect(mod).toBeInstanceOf(CriticalSuccessModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: 'cs!=45',
             comparePoint: expect.objectContaining({
               operator: '!=',
               value: 45,
@@ -324,7 +297,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('19d23');
           expect(parsed[0].sides).toEqual(23);
           expect(parsed[0].qty).toEqual(19);
 
@@ -333,7 +305,6 @@ describe('Parser', () => {
           const mod = parsed[0].modifiers.get('drop-l');
           expect(mod).toBeInstanceOf(DropModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: 'd1',
             end: 'l',
             qty: 1,
           }));
@@ -346,7 +317,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('4d10');
           expect(parsed[0].sides).toEqual(10);
           expect(parsed[0].qty).toEqual(4);
 
@@ -355,7 +325,6 @@ describe('Parser', () => {
           const mod = parsed[0].modifiers.get('drop-l');
           expect(mod).toBeInstanceOf(DropModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: 'dl1',
             end: 'l',
             qty: 1,
           }));
@@ -368,7 +337,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(PercentileDice);
 
-          expect(parsed[0].notation).toEqual('7d%');
           expect(parsed[0].sides).toEqual('%');
           expect(parsed[0].qty).toEqual(7);
 
@@ -377,7 +345,6 @@ describe('Parser', () => {
           const mod = parsed[0].modifiers.get('drop-l');
           expect(mod).toBeInstanceOf(DropModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: 'd3',
             end: 'l',
             qty: 3,
           }));
@@ -390,7 +357,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('4d6');
           expect(parsed[0].sides).toEqual(6);
           expect(parsed[0].qty).toEqual(4);
 
@@ -399,7 +365,6 @@ describe('Parser', () => {
           const mod = parsed[0].modifiers.get('drop-h');
           expect(mod).toBeInstanceOf(DropModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: 'dh2',
             end: 'h',
             qty: 2,
           }));
@@ -424,7 +389,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('d6');
           expect(parsed[0].sides).toEqual(6);
           expect(parsed[0].qty).toEqual(1);
 
@@ -433,7 +397,6 @@ describe('Parser', () => {
           const mod = parsed[0].modifiers.get('explode');
           expect(mod).toBeInstanceOf(ExplodeModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: '!',
             comparePoint: expect.objectContaining({
               operator: '=',
               value: 6,
@@ -450,7 +413,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('2d7');
           expect(parsed[0].sides).toEqual(7);
           expect(parsed[0].qty).toEqual(2);
 
@@ -459,7 +421,6 @@ describe('Parser', () => {
           const mod = parsed[0].modifiers.get('explode');
           expect(mod).toBeInstanceOf(ExplodeModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: '!!',
             comparePoint: expect.objectContaining({
               operator: '=',
               value: 7,
@@ -476,7 +437,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(PercentileDice);
 
-          expect(parsed[0].notation).toEqual('5d%');
           expect(parsed[0].sides).toEqual('%');
           expect(parsed[0].qty).toEqual(5);
 
@@ -485,7 +445,6 @@ describe('Parser', () => {
           const mod = parsed[0].modifiers.get('explode');
           expect(mod).toBeInstanceOf(ExplodeModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: '!p',
             comparePoint: expect.objectContaining({
               operator: '=',
               value: 100,
@@ -502,7 +461,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(FudgeDice);
 
-          expect(parsed[0].notation).toEqual('1dF');
           expect(parsed[0].sides).toEqual('F.2');
           expect(parsed[0].qty).toEqual(1);
 
@@ -511,7 +469,6 @@ describe('Parser', () => {
           const mod = parsed[0].modifiers.get('explode');
           expect(mod).toBeInstanceOf(ExplodeModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: '!!p',
             comparePoint: expect.objectContaining({
               operator: '=',
               value: 1,
@@ -528,7 +485,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(FudgeDice);
 
-          expect(parsed[0].notation).toEqual('4dF.2');
           expect(parsed[0].sides).toEqual('F.2');
           expect(parsed[0].qty).toEqual(4);
 
@@ -537,7 +493,6 @@ describe('Parser', () => {
           const mod = parsed[0].modifiers.get('explode');
           expect(mod).toBeInstanceOf(ExplodeModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: '!>=0',
             comparePoint: expect.objectContaining({
               operator: '>=',
               value: 0,
@@ -554,7 +509,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(FudgeDice);
 
-          expect(parsed[0].notation).toEqual('dF.1');
           expect(parsed[0].sides).toEqual('F.1');
           expect(parsed[0].qty).toEqual(1);
 
@@ -563,7 +517,6 @@ describe('Parser', () => {
           const mod = parsed[0].modifiers.get('explode');
           expect(mod).toBeInstanceOf(ExplodeModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: '!!<=1',
             comparePoint: expect.objectContaining({
               operator: '<=',
               value: 1,
@@ -580,7 +533,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(PercentileDice);
 
-          expect(parsed[0].notation).toEqual('360d%');
           expect(parsed[0].sides).toEqual('%');
           expect(parsed[0].qty).toEqual(360);
 
@@ -589,7 +541,6 @@ describe('Parser', () => {
           const mod = parsed[0].modifiers.get('explode');
           expect(mod).toBeInstanceOf(ExplodeModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: '!!p<50',
             comparePoint: expect.objectContaining({
               operator: '<',
               value: 50,
@@ -608,7 +559,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('d40601');
           expect(parsed[0].sides).toEqual(40601);
           expect(parsed[0].qty).toEqual(1);
 
@@ -616,11 +566,8 @@ describe('Parser', () => {
 
           const mod = parsed[0].modifiers.get('keep-h');
           expect(mod).toBeInstanceOf(KeepModifier);
-          expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: 'k1',
-            end: 'h',
-            qty: 1,
-          }));
+          expect(mod.end).toBe('h');
+          expect(mod.qty).toBe(1);
         });
 
         test('keep highest for `897d2kh1`', () => {
@@ -630,7 +577,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('897d2');
           expect(parsed[0].sides).toEqual(2);
           expect(parsed[0].qty).toEqual(897);
 
@@ -638,11 +584,8 @@ describe('Parser', () => {
 
           const mod = parsed[0].modifiers.get('keep-h');
           expect(mod).toBeInstanceOf(KeepModifier);
-          expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: 'kh1',
-            end: 'h',
-            qty: 1,
-          }));
+          expect(mod.end).toBe('h');
+          expect(mod.qty).toBe(1);
         });
 
         test('keep highest for `5dFk4`', () => {
@@ -652,7 +595,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('5dF');
           expect(parsed[0].sides).toEqual('F.2');
           expect(parsed[0].qty).toEqual(5);
 
@@ -660,11 +602,8 @@ describe('Parser', () => {
 
           const mod = parsed[0].modifiers.get('keep-h');
           expect(mod).toBeInstanceOf(KeepModifier);
-          expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: 'k4',
-            end: 'h',
-            qty: 4,
-          }));
+          expect(mod.end).toBe('h');
+          expect(mod.qty).toBe(4);
         });
 
         test('keep lowest for `10d%kl3`', () => {
@@ -674,7 +613,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('10d%');
           expect(parsed[0].sides).toEqual('%');
           expect(parsed[0].qty).toEqual(10);
 
@@ -682,11 +620,8 @@ describe('Parser', () => {
 
           const mod = parsed[0].modifiers.get('keep-l');
           expect(mod).toBeInstanceOf(KeepModifier);
-          expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: 'kl3',
-            end: 'l',
-            qty: 3,
-          }));
+          expect(mod.end).toBe('l');
+          expect(mod.qty).toBe(3);
         });
       });
 
@@ -698,7 +633,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('2d6');
           expect(parsed[0].sides).toEqual(6);
           expect(parsed[0].qty).toEqual(2);
 
@@ -706,10 +640,7 @@ describe('Parser', () => {
 
           const mod = parsed[0].modifiers.get('max');
           expect(mod).toBeInstanceOf(MaxModifier);
-          expect(mod.toJSON()).toEqual(expect.objectContaining({
-            max: 3,
-            notation: 'max3',
-          }));
+          expect(mod.max).toBe(3);
         });
 
         test('max for `4d20max-12`', () => {
@@ -719,7 +650,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('4d20');
           expect(parsed[0].sides).toEqual(20);
           expect(parsed[0].qty).toEqual(4);
 
@@ -727,10 +657,7 @@ describe('Parser', () => {
 
           const mod = parsed[0].modifiers.get('max');
           expect(mod).toBeInstanceOf(MaxModifier);
-          expect(mod.toJSON()).toEqual(expect.objectContaining({
-            max: -12,
-            notation: 'max-12',
-          }));
+          expect(mod.max).toBe(-12);
         });
 
         test('max for `6d%max50.45`', () => {
@@ -740,7 +667,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('6d%');
           expect(parsed[0].sides).toEqual('%');
           expect(parsed[0].qty).toEqual(6);
 
@@ -748,10 +674,7 @@ describe('Parser', () => {
 
           const mod = parsed[0].modifiers.get('max');
           expect(mod).toBeInstanceOf(MaxModifier);
-          expect(mod.toJSON()).toEqual(expect.objectContaining({
-            max: 50.45,
-            notation: 'max50.45',
-          }));
+          expect(mod.max).toBe(50.45);
         });
 
         test('throws error if no max value', () => {
@@ -779,7 +702,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('2d6');
           expect(parsed[0].sides).toEqual(6);
           expect(parsed[0].qty).toEqual(2);
 
@@ -787,10 +709,7 @@ describe('Parser', () => {
 
           const mod = parsed[0].modifiers.get('min');
           expect(mod).toBeInstanceOf(MinModifier);
-          expect(mod.toJSON()).toEqual(expect.objectContaining({
-            min: 3,
-            notation: 'min3',
-          }));
+          expect(mod.min).toBe(3);
         });
 
         test('min for `4d20min-12`', () => {
@@ -800,7 +719,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('4d20');
           expect(parsed[0].sides).toEqual(20);
           expect(parsed[0].qty).toEqual(4);
 
@@ -808,10 +726,7 @@ describe('Parser', () => {
 
           const mod = parsed[0].modifiers.get('min');
           expect(mod).toBeInstanceOf(MinModifier);
-          expect(mod.toJSON()).toEqual(expect.objectContaining({
-            min: -12,
-            notation: 'min-12',
-          }));
+          expect(mod.min).toBe(-12);
         });
 
         test('min for `6d%min50.45`', () => {
@@ -821,7 +736,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('6d%');
           expect(parsed[0].sides).toEqual('%');
           expect(parsed[0].qty).toEqual(6);
 
@@ -829,10 +743,7 @@ describe('Parser', () => {
 
           const mod = parsed[0].modifiers.get('min');
           expect(mod).toBeInstanceOf(MinModifier);
-          expect(mod.toJSON()).toEqual(expect.objectContaining({
-            min: 50.45,
-            notation: 'min50.45',
-          }));
+          expect(mod.min).toBe(50.45);
         });
 
         test('throws error if no min value', () => {
@@ -860,7 +771,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('5d10');
           expect(parsed[0].sides).toEqual(10);
           expect(parsed[0].qty).toEqual(5);
 
@@ -869,7 +779,6 @@ describe('Parser', () => {
           const mod = parsed[0].modifiers.get('re-roll');
           expect(mod).toBeInstanceOf(ReRollModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: 'r',
             once: false,
             comparePoint: expect.objectContaining({
               operator: '=',
@@ -885,7 +794,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(FudgeDice);
 
-          expect(parsed[0].notation).toEqual('12dF');
           expect(parsed[0].sides).toEqual('F.2');
           expect(parsed[0].qty).toEqual(12);
 
@@ -894,7 +802,6 @@ describe('Parser', () => {
           const mod = parsed[0].modifiers.get('re-roll');
           expect(mod).toBeInstanceOf(ReRollModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: 'r',
             once: false,
             comparePoint: expect.objectContaining({
               operator: '=',
@@ -910,7 +817,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('2d%');
           expect(parsed[0].sides).toEqual('%');
           expect(parsed[0].qty).toEqual(2);
 
@@ -919,7 +825,6 @@ describe('Parser', () => {
           const mod = parsed[0].modifiers.get('re-roll');
           expect(mod).toBeInstanceOf(ReRollModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: 'r>80',
             once: false,
             comparePoint: expect.objectContaining({
               operator: '>',
@@ -935,7 +840,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(FudgeDice);
 
-          expect(parsed[0].notation).toEqual('35dF.1');
           expect(parsed[0].sides).toEqual('F.1');
           expect(parsed[0].qty).toEqual(35);
 
@@ -944,7 +848,6 @@ describe('Parser', () => {
           const mod = parsed[0].modifiers.get('re-roll');
           expect(mod).toBeInstanceOf(ReRollModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: 'ro',
             once: true,
             comparePoint: expect.objectContaining({
               operator: '=',
@@ -960,7 +863,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('d64');
           expect(parsed[0].sides).toEqual(64);
           expect(parsed[0].qty).toEqual(1);
 
@@ -969,7 +871,6 @@ describe('Parser', () => {
           const mod = parsed[0].modifiers.get('re-roll');
           expect(mod).toBeInstanceOf(ReRollModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: 'ro<=35',
             once: true,
             comparePoint: expect.objectContaining({
               operator: '<=',
@@ -987,7 +888,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('10d5');
           expect(parsed[0].sides).toEqual(5);
           expect(parsed[0].qty).toEqual(10);
 
@@ -995,10 +895,7 @@ describe('Parser', () => {
 
           const mod = parsed[0].modifiers.get('sorting');
           expect(mod).toBeInstanceOf(SortingModifier);
-          expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: 's',
-            direction: 'a',
-          }));
+          expect(mod.direction).toBe('a');
         });
 
         test('sort ascending for 23dF.1sa', () => {
@@ -1008,7 +905,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(FudgeDice);
 
-          expect(parsed[0].notation).toEqual('23dF.1');
           expect(parsed[0].sides).toEqual('F.1');
           expect(parsed[0].qty).toEqual(23);
 
@@ -1016,10 +912,7 @@ describe('Parser', () => {
 
           const mod = parsed[0].modifiers.get('sorting');
           expect(mod).toBeInstanceOf(SortingModifier);
-          expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: 'sa',
-            direction: 'a',
-          }));
+          expect(mod.direction).toBe('a');
         });
 
         test('sort descending for 14d%sd', () => {
@@ -1029,7 +922,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(PercentileDice);
 
-          expect(parsed[0].notation).toEqual('14d%');
           expect(parsed[0].sides).toEqual('%');
           expect(parsed[0].qty).toEqual(14);
 
@@ -1037,10 +929,7 @@ describe('Parser', () => {
 
           const mod = parsed[0].modifiers.get('sorting');
           expect(mod).toBeInstanceOf(SortingModifier);
-          expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: 'sd',
-            direction: 'd',
-          }));
+          expect(mod.direction).toBe('d');
         });
       });
 
@@ -1053,7 +942,6 @@ describe('Parser', () => {
             expect(parsed).toHaveLength(1);
             expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-            expect(parsed[0].notation).toEqual('8d45');
             expect(parsed[0].sides).toEqual(45);
             expect(parsed[0].qty).toEqual(8);
 
@@ -1062,7 +950,6 @@ describe('Parser', () => {
             const mod = parsed[0].modifiers.get('target');
             expect(mod).toBeInstanceOf(TargetModifier);
             expect(mod.toJSON()).toEqual(expect.objectContaining({
-              notation: '=21',
               successComparePoint: expect.objectContaining({
                 operator: '=',
                 value: 21,
@@ -1078,7 +965,6 @@ describe('Parser', () => {
             expect(parsed).toHaveLength(1);
             expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-            expect(parsed[0].notation).toEqual('dF');
             expect(parsed[0].sides).toEqual('F.2');
             expect(parsed[0].qty).toEqual(1);
 
@@ -1087,7 +973,6 @@ describe('Parser', () => {
             const mod = parsed[0].modifiers.get('target');
             expect(mod).toBeInstanceOf(TargetModifier);
             expect(mod.toJSON()).toEqual(expect.objectContaining({
-              notation: '>=0',
               successComparePoint: expect.objectContaining({
                 operator: '>=',
                 value: 0,
@@ -1105,7 +990,6 @@ describe('Parser', () => {
             expect(parsed).toHaveLength(1);
             expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-            expect(parsed[0].notation).toEqual('4d%');
             expect(parsed[0].sides).toEqual('%');
             expect(parsed[0].qty).toEqual(4);
 
@@ -1114,7 +998,6 @@ describe('Parser', () => {
             const mod = parsed[0].modifiers.get('target');
             expect(mod).toBeInstanceOf(TargetModifier);
             expect(mod.toJSON()).toEqual(expect.objectContaining({
-              notation: '>50f<40',
               successComparePoint: expect.objectContaining({
                 operator: '>',
                 value: 50,
@@ -1133,7 +1016,6 @@ describe('Parser', () => {
             expect(parsed).toHaveLength(1);
             expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-            expect(parsed[0].notation).toEqual('450dF.1');
             expect(parsed[0].sides).toEqual('F.1');
             expect(parsed[0].qty).toEqual(450);
 
@@ -1142,7 +1024,6 @@ describe('Parser', () => {
             const mod = parsed[0].modifiers.get('target');
             expect(mod).toBeInstanceOf(TargetModifier);
             expect(mod.toJSON()).toEqual(expect.objectContaining({
-              notation: '>0f!=1',
               successComparePoint: expect.objectContaining({
                 operator: '>',
                 value: 0,
@@ -1176,7 +1057,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('6d10');
           expect(parsed[0].sides).toEqual(10);
           expect(parsed[0].qty).toEqual(6);
 
@@ -1185,7 +1065,6 @@ describe('Parser', () => {
           let mod = parsed[0].modifiers.get('target');
           expect(mod).toBeInstanceOf(TargetModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: '>=8',
             successComparePoint: expect.objectContaining({
               operator: '>=',
               value: 8,
@@ -1198,7 +1077,6 @@ describe('Parser', () => {
           mod = parsed[0].modifiers.get('explode');
           expect(mod).toBeInstanceOf(ExplodeModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: '!>=9',
             comparePoint: expect.objectContaining({
               operator: '>=',
               value: 9,
@@ -1216,7 +1094,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('6d10');
           expect(parsed[0].sides).toEqual(10);
           expect(parsed[0].qty).toEqual(6);
 
@@ -1225,7 +1102,6 @@ describe('Parser', () => {
           let mod = parsed[0].modifiers.get('target');
           expect(mod).toBeInstanceOf(TargetModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: '>=8',
             successComparePoint: expect.objectContaining({
               operator: '>=',
               value: 8,
@@ -1238,7 +1114,6 @@ describe('Parser', () => {
           mod = parsed[0].modifiers.get('explode');
           expect(mod).toBeInstanceOf(ExplodeModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: '!>=9',
             comparePoint: expect.objectContaining({
               operator: '>=',
               value: 9,
@@ -1255,7 +1130,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('10d8');
           expect(parsed[0].sides).toEqual(8);
           expect(parsed[0].qty).toEqual(10);
 
@@ -1263,28 +1137,21 @@ describe('Parser', () => {
 
           let mod = parsed[0].modifiers.get('drop-h');
           expect(mod).toBeInstanceOf(DropModifier);
-          expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: 'dh2',
-            end: 'h',
-            qty: 2,
-          }));
+          expect(mod.end).toBe('h');
+          expect(mod.qty).toBe(2);
 
           expect(parsed[0].modifiers.has('keep-l')).toBe(true);
 
           mod = parsed[0].modifiers.get('keep-l');
           expect(mod).toBeInstanceOf(KeepModifier);
-          expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: 'kl3',
-            end: 'l',
-            qty: 3,
-          }));
+          expect(mod.end).toBe('l');
+          expect(mod.qty).toBe(3);
 
           expect(parsed[0].modifiers.has('re-roll')).toBe(true);
 
           mod = parsed[0].modifiers.get('re-roll');
           expect(mod).toBeInstanceOf(ReRollModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: 'r!=5',
             once: false,
             comparePoint: expect.objectContaining({
               operator: '!=',
@@ -1300,7 +1167,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('4d10');
           expect(parsed[0].sides).toEqual(10);
           expect(parsed[0].qty).toEqual(4);
 
@@ -1308,19 +1174,13 @@ describe('Parser', () => {
 
           let mod = parsed[0].modifiers.get('min');
           expect(mod).toBeInstanceOf(MinModifier);
-          expect(mod.toJSON()).toEqual(expect.objectContaining({
-            min: 3,
-            notation: 'min3',
-          }));
+          expect(mod.min).toBe(3);
 
           expect(parsed[0].modifiers.has('max')).toBe(true);
 
           mod = parsed[0].modifiers.get('max');
           expect(mod).toBeInstanceOf(MaxModifier);
-          expect(mod.toJSON()).toEqual(expect.objectContaining({
-            max: 6,
-            notation: 'max6',
-          }));
+          expect(mod.max).toBe(6);
         });
 
         test('use Max followed by Min', () => {
@@ -1330,7 +1190,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('4d10');
           expect(parsed[0].sides).toEqual(10);
           expect(parsed[0].qty).toEqual(4);
 
@@ -1338,19 +1197,13 @@ describe('Parser', () => {
 
           let mod = parsed[0].modifiers.get('min');
           expect(mod).toBeInstanceOf(MinModifier);
-          expect(mod.toJSON()).toEqual(expect.objectContaining({
-            min: 3,
-            notation: 'min3',
-          }));
+          expect(mod.min).toBe(3);
 
           expect(parsed[0].modifiers.has('max')).toBe(true);
 
           mod = parsed[0].modifiers.get('max');
           expect(mod).toBeInstanceOf(MaxModifier);
-          expect(mod.toJSON()).toEqual(expect.objectContaining({
-            max: 6,
-            notation: 'max6',
-          }));
+          expect(mod.max).toBe(6);
         });
 
         test('multiple of the same operator just keeps the last one', () => {
@@ -1360,7 +1213,6 @@ describe('Parser', () => {
           expect(parsed).toHaveLength(1);
           expect(parsed[0]).toBeInstanceOf(StandardDice);
 
-          expect(parsed[0].notation).toEqual('42d2');
           expect(parsed[0].sides).toEqual(2);
           expect(parsed[0].qty).toEqual(42);
 
@@ -1369,7 +1221,6 @@ describe('Parser', () => {
           const mod = parsed[0].modifiers.get('explode');
           expect(mod).toBeInstanceOf(ExplodeModifier);
           expect(mod.toJSON()).toEqual(expect.objectContaining({
-            notation: '!p<5',
             comparePoint: expect.objectContaining({
               operator: '<',
               value: 5,
@@ -1388,11 +1239,9 @@ describe('Parser', () => {
         expect(parsed).toBeInstanceOf(Array);
         expect(parsed).toHaveLength(1);
         expect(parsed[0]).toBeInstanceOf(StandardDice);
-        expect(parsed[0]).toEqual(expect.objectContaining({
-          notation: '(4*6)d6',
-          sides: 6,
-          qty: 24,
-        }));
+        expect(parsed[0].sides).toBe(6);
+        expect(parsed[0].qty).toBe(24);
+        expect(parsed[0].modifiers).toEqual(new Map());
       });
 
       test('can parse `3d(5/2)`', () => {
@@ -1401,11 +1250,9 @@ describe('Parser', () => {
         expect(parsed).toBeInstanceOf(Array);
         expect(parsed).toHaveLength(1);
         expect(parsed[0]).toBeInstanceOf(StandardDice);
-        expect(parsed[0]).toEqual(expect.objectContaining({
-          notation: '3d(5/2)',
-          sides: 2.5,
-          qty: 3,
-        }));
+        expect(parsed[0].sides).toBe(2.5);
+        expect(parsed[0].qty).toBe(3);
+        expect(parsed[0].modifiers).toEqual(new Map());
       });
 
       test('can parse `(5^2*4)d(7%4)`', () => {
@@ -1414,11 +1261,9 @@ describe('Parser', () => {
         expect(parsed).toBeInstanceOf(Array);
         expect(parsed).toHaveLength(1);
         expect(parsed[0]).toBeInstanceOf(StandardDice);
-        expect(parsed[0]).toEqual(expect.objectContaining({
-          notation: '(5^2*4)d(7%4)',
-          sides: 3,
-          qty: 100,
-        }));
+        expect(parsed[0].sides).toBe(3);
+        expect(parsed[0].qty).toBe(100);
+        expect(parsed[0].modifiers).toEqual(new Map());
       });
     });
 
@@ -1434,11 +1279,9 @@ describe('Parser', () => {
           expect(parsed[0]).toEqual(`${name}(`);
 
           expect(parsed[1]).toBeInstanceOf(StandardDice);
-          expect(parsed[1]).toEqual(expect.objectContaining({
-            notation: '4d6',
-            sides: 6,
-            qty: 4,
-          }));
+          expect(parsed[1].sides).toBe(6);
+          expect(parsed[1].qty).toBe(4);
+          expect(parsed[1].modifiers).toEqual(new Map());
 
           expect(parsed[2]).toEqual('/');
           expect(parsed[3]).toBe(3);
@@ -1463,11 +1306,9 @@ describe('Parser', () => {
           expect(parsed[0]).toEqual(`${name}(`);
 
           expect(parsed[1]).toBeInstanceOf(StandardDice);
-          expect(parsed[1]).toEqual(expect.objectContaining({
-            notation: '4d6',
-            sides: 6,
-            qty: 4,
-          }));
+          expect(parsed[1].sides).toBe(6);
+          expect(parsed[1].qty).toBe(4);
+          expect(parsed[1].modifiers).toEqual(new Map());
 
           expect(parsed[2]).toEqual(',');
           expect(parsed[3]).toBe(7);
@@ -1490,20 +1331,16 @@ describe('Parser', () => {
         expect(parsed).toHaveLength(3);
 
         expect(parsed[0]).toBeInstanceOf(StandardDice);
-        expect(parsed[0]).toEqual(expect.objectContaining({
-          notation: '6d10',
-          sides: 10,
-          qty: 6,
-        }));
+        expect(parsed[0].sides).toBe(10);
+        expect(parsed[0].qty).toBe(6);
+        expect(parsed[0].modifiers).toEqual(new Map());
 
         expect(parsed[1]).toEqual('*');
 
         expect(parsed[2]).toBeInstanceOf(FudgeDice);
-        expect(parsed[2]).toEqual(expect.objectContaining({
-          notation: '4dF.1',
-          sides: 'F.1',
-          qty: 4,
-        }));
+        expect(parsed[2].sides).toBe('F.1');
+        expect(parsed[2].qty).toBe(4);
+        expect(parsed[2].modifiers).toEqual(new Map());
       });
 
       test('can parse `(10d7/2d3)*4`', () => {
@@ -1515,20 +1352,16 @@ describe('Parser', () => {
         expect(parsed[0]).toEqual('(');
 
         expect(parsed[1]).toBeInstanceOf(StandardDice);
-        expect(parsed[1]).toEqual(expect.objectContaining({
-          notation: '10d7',
-          sides: 7,
-          qty: 10,
-        }));
+        expect(parsed[1].sides).toBe(7);
+        expect(parsed[1].qty).toBe(10);
+        expect(parsed[1].modifiers).toEqual(new Map());
 
         expect(parsed[2]).toEqual('/');
 
         expect(parsed[3]).toBeInstanceOf(PercentileDice);
-        expect(parsed[3]).toEqual(expect.objectContaining({
-          notation: '2d%',
-          sides: '%',
-          qty: 2,
-        }));
+        expect(parsed[3].sides).toBe('%');
+        expect(parsed[3].qty).toBe(2);
+        expect(parsed[3].modifiers).toEqual(new Map());
 
         expect(parsed[4]).toEqual(')');
         expect(parsed[5]).toEqual('*');
@@ -1542,11 +1375,9 @@ describe('Parser', () => {
         expect(parsed).toHaveLength(7);
 
         expect(parsed[0]).toBeInstanceOf(PercentileDice);
-        expect(parsed[0]).toEqual(expect.objectContaining({
-          notation: 'd%',
-          sides: '%',
-          qty: 1,
-        }));
+        expect(parsed[0].sides).toBe('%');
+        expect(parsed[0].qty).toBe(1);
+        expect(parsed[0].modifiers).toEqual(new Map());
 
         expect(parsed[1]).toEqual('%');
         expect(parsed[2]).toEqual('(');
@@ -1567,11 +1398,9 @@ describe('Parser', () => {
         expect(parsed[2]).toEqual('^');
 
         expect(parsed[3]).toBeInstanceOf(FudgeDice);
-        expect(parsed[3]).toEqual(expect.objectContaining({
-          notation: '3dF',
-          sides: 'F.2',
-          qty: 3,
-        }));
+        expect(parsed[3].sides).toBe('F.2');
+        expect(parsed[3].qty).toBe(3);
+        expect(parsed[3].modifiers).toEqual(new Map());
 
         expect(parsed[4]).toEqual(')');
         expect(parsed[5]).toEqual('*');
@@ -1580,11 +1409,9 @@ describe('Parser', () => {
         expect(parsed[8]).toEqual('(');
 
         expect(parsed[9]).toBeInstanceOf(StandardDice);
-        expect(parsed[9]).toEqual(expect.objectContaining({
-          notation: '10d45',
-          sides: 45,
-          qty: 10,
-        }));
+        expect(parsed[9].sides).toBe(45);
+        expect(parsed[9].qty).toBe(10);
+        expect(parsed[9].modifiers).toEqual(new Map());
 
         expect(parsed[10]).toEqual('/');
         expect(parsed[11]).toEqual('(');
@@ -1604,11 +1431,9 @@ describe('Parser', () => {
         expect(parsed[0]).toEqual('(');
 
         expect(parsed[1]).toBeInstanceOf(StandardDice);
-        expect(parsed[1]).toEqual(expect.objectContaining({
-          notation: '(4*2)d10',
-          sides: 10,
-          qty: 8,
-        }));
+        expect(parsed[1].sides).toBe(10);
+        expect(parsed[1].qty).toBe(8);
+        expect(parsed[1].modifiers).toEqual(new Map());
 
         expect(parsed[2]).toEqual('/');
         expect(parsed[3]).toBe(4);
@@ -1619,11 +1444,9 @@ describe('Parser', () => {
         expect(parsed[8]).toEqual('(');
 
         expect(parsed[9]).toBeInstanceOf(PercentileDice);
-        expect(parsed[9]).toEqual(expect.objectContaining({
-          notation: 'd%',
-          sides: '%',
-          qty: 1,
-        }));
+        expect(parsed[9].sides).toBe('%');
+        expect(parsed[9].qty).toBe(1);
+        expect(parsed[9].modifiers).toEqual(new Map());
 
         expect(parsed[10]).toEqual('-');
         expect(parsed[11]).toBe(2);
@@ -1641,11 +1464,9 @@ describe('Parser', () => {
         expect(parsed[2]).toEqual('floor(');
 
         expect(parsed[3]).toBeInstanceOf(StandardDice);
-        expect(parsed[3]).toEqual(expect.objectContaining({
-          notation: '4d10',
-          sides: 10,
-          qty: 4,
-        }));
+        expect(parsed[3].sides).toBe(10);
+        expect(parsed[3].qty).toBe(4);
+        expect(parsed[3].modifiers).toEqual(new Map());
 
         expect(parsed[4]).toEqual('/');
         expect(parsed[5]).toBe(3.4);
@@ -1659,18 +1480,14 @@ describe('Parser', () => {
         expect(parsed).toHaveLength(7);
 
         expect(parsed[0]).toBeInstanceOf(StandardDice);
-        expect(parsed[0]).toEqual(expect.objectContaining({
-          notation: '4d10',
-          sides: 10,
-          qty: 4,
-        }));
+        expect(parsed[0].sides).toBe(10);
+        expect(parsed[0].qty).toBe(4);
 
         expect(parsed[0].modifiers.has('explode')).toBe(true);
 
         let mod = parsed[0].modifiers.get('explode');
         expect(mod).toBeInstanceOf(ExplodeModifier);
         expect(mod.toJSON()).toEqual(expect.objectContaining({
-          notation: '!!p',
           comparePoint: expect.objectContaining({
             operator: '=',
             value: 10,
@@ -1685,18 +1502,14 @@ describe('Parser', () => {
         expect(parsed[4]).toEqual('*');
 
         expect(parsed[5]).toBeInstanceOf(StandardDice);
-        expect(parsed[5]).toEqual(expect.objectContaining({
-          notation: 'd12',
-          sides: 12,
-          qty: 1,
-        }));
+        expect(parsed[5].sides).toBe(12);
+        expect(parsed[5].qty).toBe(1);
 
         expect(parsed[5].modifiers.has('re-roll')).toBe(true);
 
         mod = parsed[5].modifiers.get('re-roll');
         expect(mod).toBeInstanceOf(ReRollModifier);
         expect(mod.toJSON()).toEqual(expect.objectContaining({
-          notation: 'r',
           once: false,
           comparePoint: expect.objectContaining({
             operator: '=',
@@ -1713,11 +1526,9 @@ describe('Parser', () => {
         expect(parsed).toBeInstanceOf(Array);
         expect(parsed).toHaveLength(1);
         expect(parsed[0]).toBeInstanceOf(StandardDice);
-        expect(parsed[0]).toEqual(expect.objectContaining({
-          notation: '999d6',
-          sides: 6,
-          qty: 999,
-        }));
+        expect(parsed[0].sides).toBe(6);
+        expect(parsed[0].qty).toBe(999);
+        expect(parsed[0].modifiers).toEqual(new Map());
       });
 
       test('can roll with a stupidly high sides', () => {
@@ -1726,11 +1537,9 @@ describe('Parser', () => {
         expect(parsed).toBeInstanceOf(Array);
         expect(parsed).toHaveLength(1);
         expect(parsed[0]).toBeInstanceOf(StandardDice);
-        expect(parsed[0]).toEqual(expect.objectContaining({
-          notation: 'd9999999999',
-          sides: 9999999999,
-          qty: 1,
-        }));
+        expect(parsed[0].sides).toBe(9999999999);
+        expect(parsed[0].qty).toBe(1);
+        expect(parsed[0].modifiers).toEqual(new Map());
       });
 
       test('can roll with a qty of 999 and stupidly high sides', () => {
@@ -1739,11 +1548,9 @@ describe('Parser', () => {
         expect(parsed).toBeInstanceOf(Array);
         expect(parsed).toHaveLength(1);
         expect(parsed[0]).toBeInstanceOf(StandardDice);
-        expect(parsed[0]).toEqual(expect.objectContaining({
-          notation: '999d9999999999',
-          sides: 9999999999,
-          qty: 999,
-        }));
+        expect(parsed[0].sides).toBe(9999999999);
+        expect(parsed[0].qty).toBe(999);
+        expect(parsed[0].modifiers).toEqual(new Map());
       });
     });
 
@@ -1755,11 +1562,9 @@ describe('Parser', () => {
         expect(parsed).toHaveLength(3);
 
         expect(parsed[0]).toBeInstanceOf(StandardDice);
-        expect(parsed[0]).toEqual(expect.objectContaining({
-          notation: '1d20',
-          sides: 20,
-          qty: 1,
-        }));
+        expect(parsed[0].sides).toBe(20);
+        expect(parsed[0].qty).toBe(1);
+        expect(parsed[0].modifiers).toEqual(new Map());
 
         expect(parsed[1]).toEqual('+');
         expect(parsed[2]).toBe(-5);
@@ -1775,11 +1580,9 @@ describe('Parser', () => {
         expect(parsed[1]).toEqual('*');
 
         expect(parsed[2]).toBeInstanceOf(StandardDice);
-        expect(parsed[2]).toEqual(expect.objectContaining({
-          notation: '1d20',
-          sides: 20,
-          qty: 1,
-        }));
+        expect(parsed[2].sides).toBe(20);
+        expect(parsed[2].qty).toBe(1);
+        expect(parsed[2].modifiers).toEqual(new Map());
       });
 
       test('can parse `(-2+5)d(6+-4)`', () => {
@@ -1787,12 +1590,11 @@ describe('Parser', () => {
 
         expect(parsed).toBeInstanceOf(Array);
         expect(parsed).toHaveLength(1);
+
         expect(parsed[0]).toBeInstanceOf(StandardDice);
-        expect(parsed[0]).toEqual(expect.objectContaining({
-          notation: '(-2+5)d(6+-4)',
-          sides: 2,
-          qty: 3,
-        }));
+        expect(parsed[0].sides).toBe(2);
+        expect(parsed[0].qty).toBe(3);
+        expect(parsed[0].modifiers).toEqual(new Map());
       });
 
       test('throws error when using negative values for die quantity', () => {


### PR DESCRIPTION
Resolves #175 