### PR TITLE
Feature/package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     },
     "./lib/umd/bundle.js": {
       "require": "./lib/umd/bundle.js"
-    }
+    },
+    "./src/": "./src/",
+    "./types/": "./types/",
+    "./package.json": "./package.json"
   },
   "types": "./types/index.d.ts",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "random-js": "^2.1.0"
   },
   "engines": {
-    "node": ">=11.0"
+    "node": ">=12.0"
   },
   "scripts": {
     "build": "npm run build:prod",


### PR DESCRIPTION
This exports more files in `package.json`, enabling users to import all relevant files:

- `package.json`
- `./src/` directory (In case people want to access the source folder directly)
- `./types/` directory (In case you need to access the type definitions directly using Typescript)

It also bumps the recommended node from to `>=12.0`, which is the oldest version that supports ES modules, and the [`exports` property](https://nodejs.org/api/esm.html#esm_package_entry_points).
Although there's still the `main` and `module` entries as fallbacks for older versions.