### PR TITLE
Feature/rollup multiple builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ bower_components
 ## Compiled scripts
 /lib/*.js
 /lib/**/*.js
+/lib/*.map
+/lib/**/*.map
 /src/parser/grammars/grammar.js
 
 ## Compiled TypeScript

--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,8 @@
 # Except for these
 !/lib/*.js
 !/lib/**/*.js
+!/lib/*.map
+!/lib/**/*.map
 !/types/*.d.ts
 !/types/**/*.d.ts
 !CONTRIBUTING.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
     - master
     - develop
 script:
-  - npm run test:coveralls
+  - npm run test:coverage && coveralls < coverage/lcov.info
 env:
   global:
     - COVERALLS_PARALLEL=true

--- a/banner.txt
+++ b/banner.txt
@@ -1,6 +1,6 @@
 <%= pkg.name %> - <%= pkg.description %>
 
-@version v<%= pkg.version %>
+@version <%= pkg.version %>
 @license <%= pkg.license %>
 @author <%= pkg.author %>
 @link <%= pkg.homepage %>

--- a/package.json
+++ b/package.json
@@ -70,23 +70,19 @@
     "node": ">=12.0"
   },
   "scripts": {
-    "build": "npm run build:prod",
-    "build:prod": "npm run prebuild && npm run build:umd -- --environment BUILD:prod && npm run build:esm -- --environment BUILD:prod",
-    "build:dev": "npm run prebuild && npm run build:esm -- --environment BUILD:dev && npm run build:umd -- --environment BUILD:dev",
-    "build:umd": "rollup --c --environment FORMAT:umd",
-    "build:esm": "rollup --c --environment FORMAT:esm",
-    "build:grammars": "node --experimental-modules src/parser/grammars/generate.js",
+    "build": "npm run build:dev && npm run build:prod && npm run build:declaration",
     "build:declaration": "rm -rf types/ && tsc -p declaration.tsconfig.json",
+    "build:dev": "npm run build:grammars && rollup --c --environment BUILD:dev",
     "build:docs": "./node_modules/vuepress-jsdoc/bin/vuepress-jsdoc.js --dist ./docs --folder api --exclude parser/grammars/*.js,RollGroup.js",
-    "prebuild": "npm run build:grammars",
-    "watch": "npm run prebuild && npm run build:esm -- --environment BUILD:dev -w",
+    "build:grammars": "node src/parser/grammars/generate.js",
+    "build:prod": "npm run build:grammars && rollup --c --environment BUILD:prod",
+    "watch": "npm run build:dev -- -w",
     "lint": "eslint src/** tests/**",
     "lint:fix": "eslint --fix src/** tests/**",
-    "pretest": "npm run prebuild && npm run build:declaration && npm run lint",
+    "pretest": "npm run build:grammars && npm run build:declaration && npm run lint",
     "test": "jest",
-    "test:watch": "npm run pretest && jest --watchAll",
     "test:coverage": "npm run pretest && jest --coverage",
-    "test:coveralls": "npm run test:coverage && coveralls < coverage/lcov.info",
-    "prepublishOnly": "npm test && npm run build:prod && npm run build:dev"
+    "test:watch": "npm run pretest && jest --watchAll",
+    "prepublishOnly": "npm test && npm run build"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,37 +7,55 @@ const { terser } = require('rollup-plugin-terser');
 const { eslint } = require('rollup-plugin-eslint');
 const path = require('path');
 
-const format = process.env.FORMAT || 'esm';
 const production = !process.env.BUILD || (process.env.BUILD === 'prod');
-const es6 = format === 'esm';
 
-export default {
-  input: 'src/index.js',
-  output: {
-    file: `lib/${format}/bundle${production ? '.min' : ''}.js`,
-    format,
-    name: 'rpgDiceRoller',
-    // map external dependencies to variables, for UMD builds
-    globals: !es6 ? {
-      'random-js': 'randomJs',
-    } : {},
+const inputPath = 'src/index.js';
+const outputPath = (format, minify = false) => `lib/${format}/bundle${minify ? '.min' : ''}.js`;
+const packageName = 'rpgDiceRoller';
+
+/**
+ * Returns a list of common plugins
+ *
+ * @param {boolean} [isUmd=false]
+ * @param {boolean} [isProduction=false]
+ * @returns {{}}
+ */
+const plugins = (isUmd = false, isProduction = false) => [
+  // lint the files
+  eslint(),
+  // resolve third party library imports
+  resolve(),
+  // handle commonJS modules
+  commonjs(),
+  // only use babel if we're compiling to UMD
+  isUmd ? babel({
+    exclude: 'node_modules/**',
+  }) : null,
+  // minify for production
+  isProduction ? terser({ keep_classnames: true }) : null,
+  banner({
+    file: path.join(__dirname, 'banner.txt'),
+  }),
+];
+
+export default [
+  // ESM
+  {
+    input: inputPath,
+    output: {
+      file: outputPath('esm', production),
+      format: 'esm',
+    },
+    plugins: plugins(false, production),
   },
-  plugins: [
-    // lint the files
-    eslint(),
-    // resolve third party library imports
-    resolve(),
-    // handle commonJS modules
-    commonjs(),
-    !es6 ? babel({
-      exclude: 'node_modules/**',
-    }) : null,
-    // minify for production
-    production ? terser({ keep_classnames: true }) : null,
-    banner({
-      file: path.join(__dirname, 'banner.txt'),
-    }),
-  ],
-  // indicate which modules should be treated as external
-  external: [],
-};
+  // UMD
+  {
+    input: inputPath,
+    output: {
+      file: outputPath('umd', production),
+      format: 'umd',
+      name: packageName,
+    },
+    plugins: plugins(true, production),
+  },
+];

--- a/src/parser/grammars/generate.js
+++ b/src/parser/grammars/generate.js
@@ -13,11 +13,11 @@ const grammar = fs.readFileSync(`${dir}${sourceFilename}`).toString();
 const parser = pegjs.generate(grammar, { output: 'source', format: 'commonjs' });
 
 // convert parser to ES module
-const output = `import * as Dice from '../../dice';
+const output = `import math from 'mathjs-expression-parser';
+import * as Dice from '../../dice';
 import * as Modifiers from '../../modifiers';
 import ComparePoint from '../../ComparePoint';
 import RollGroup from '../../RollGroup';
-import math from 'mathjs-expression-parser';
 
 const module = {};
 
@@ -26,7 +26,8 @@ ${parser}
 export {
   peg$SyntaxError as SyntaxError,
   peg$parse as parse,
-}`;
+};
+`;
 
 // create the file
 fs.writeFileSync(`${dir}${outputFilename}`, output);


### PR DESCRIPTION
Compile both ESM and UMD bundles together

Rollup supports multiple configs, so we don't need to run two scripts to bundle them anymore.

Remove unnecessary `build:esm` and `build:umd` scripts.

Consolidates package scripts (Mainly removing unnecessary `build:esm` and `build:umd` scripts).