### PR TITLE
Run `build:declaration` as separate job in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,16 @@ branches:
   only:
     - master
     - develop
-script:
-  - npm run test:coverage && coveralls < coverage/lcov.info
+jobs:
+  include:
+    - stage: "test"
+      name: "General tests"
+      script: npm run test:coverage && coveralls < coverage/lcov.info
+    - stage: "Build"
+      name: "Typescript declaration build"
+      script: npm run build:declaration
+    - script: npm run build:docs
+      name: "Docs build"
 env:
   global:
     - COVERALLS_PARALLEL=true

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "watch": "npm run build:dev -- -w",
     "lint": "eslint src/** tests/**",
     "lint:fix": "eslint --fix src/** tests/**",
-    "pretest": "npm run build:grammars && npm run build:declaration && npm run lint",
+    "pretest": "npm run build:grammars && npm run lint",
     "test": "jest",
     "test:coverage": "npm run pretest && jest --coverage",
     "test:watch": "npm run pretest && jest --watchAll",


### PR DESCRIPTION
Don't run it in `pretest` as it just slows down testing (Especially locally), when we usually don't need to test declarations.