### PR TITLE
Fix missing type argument in DiceRoll

### DIFF
--- a/src/DiceRoll.js
+++ b/src/DiceRoll.js
@@ -113,7 +113,8 @@ class DiceRoll {
    *   rolls: ..., // RollResults object or array of roll results
    * });
    *
-   * @param {string|{notation: string, rolls: ResultGroup|Array}} notation The notation to roll
+   * @param {string|{notation: string, rolls: ResultGroup|Array<ResultGroup>}} notation The
+   * notation to roll
    * @param {string} notation.notation If `notation is an object; the notation to roll
    * @param {ResultGroup|Array.<ResultGroup|RollResults|string|number>} [notation.rolls] If
    * `notation` is an object; the rolls to import


### PR DESCRIPTION
This fixes a slight error in the JSDoc of DiceRoll.js on line 115 - it was a generic without a type parameter, and resulted in this error
when I tried to compile a project that used this as a dependency

```
node_modules/rpg-dice-roller/types/DiceRoll.d.ts:66:30 - error TS2314: Generic type 'Array<T>' requires 1 type argument(s).

66         rolls: ResultGroup | Array;

Found 1 error.
```

I've changed this to Array<ResultGroup>, which does split it into two lines but I believe the formatting is in keeping with the rest of the project.